### PR TITLE
[WIP] Update serializers to accept a "timer" argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,24 @@ Regular sanity checks will be performed on relevant data. See the `OPTIONS`
 response for a particular endpoint for details on required fields and data
 formats.
 
+#### Timer Field
+
+The "timer" field is a special field available for `POST` operations to model
+endpoints supporting duration (Feeding, Sleep, Tummy Time). When the "timer"
+field is set in the request, the `start` and `end` fields will be filled in
+automatically using the `start` and `end` values *from the Timer* (the Timer
+will be stopped if it is currently running).
+
+Additionally, if the Timer has a Child relationship, the `child` field will be
+filled in automatically use the `child` value from the Timer.
+
+If the "timer" field is set, it's values will **always override** the relevant
+fields in the request. E.g. if a `POST` request is sent with both the `timer`
+and `end` fields, the value for the `end` field will be ignored and replaced by
+the Timer's `end` value. The same applies for `start` and `child`. These fields
+can all be left out of the request when the Timer is provided, otherwise they
+are required fields.
+
 #### Response
 
 Returns JSON data in the response body describing the added/updated instance or

--- a/api/mixins.py
+++ b/api/mixins.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+
+from rest_framework.response import Response
+
+
+class TimerFieldSupportMixin:
+    def options(self, request, *args, **kwargs):
+        """
+        Add information about the optional "timer" field.
+        """
+        meta = self.metadata_class()
+        data = meta.determine_metadata(request, self)
+        post = data.get('actions').get('POST')  # type: OrderedDict
+        post['timer'] = OrderedDict({
+            "type": "integer",
+            "required": False,
+            "read_only": False,
+            "label": "Timer",
+            "details": "ID for an existing Timer, may be used in place of the "
+                       "`start`, `end`, and/or `child` fields. "
+        })
+        details = "Required unless a value is provided in the `timer` field."
+        post['child']['details'] = details
+        post['start']['details'] = details
+        post['end']['details'] = details
+        return Response(data)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -59,7 +59,7 @@ class CoreModelWithDurationSerializer(CoreModelSerializer):
                 end = timer.end
             else:
                 end = timezone.now()
-            if 'child' not in attrs and timer.child:
+            if timer.child:
                 attrs['child'] = timer.child
 
             # Overwrites values provided directly!

--- a/api/views.py
+++ b/api/views.py
@@ -4,6 +4,7 @@ from rest_framework import viewsets
 from core import models
 
 from . import serializers
+from .mixins import TimerFieldSupportMixin
 
 
 class ChildViewSet(viewsets.ModelViewSet):
@@ -19,7 +20,7 @@ class DiaperChangeViewSet(viewsets.ModelViewSet):
     filterset_fields = ('child', 'wet', 'solid', 'color', 'amount')
 
 
-class FeedingViewSet(viewsets.ModelViewSet):
+class FeedingViewSet(TimerFieldSupportMixin, viewsets.ModelViewSet):
     queryset = models.Feeding.objects.all()
     serializer_class = serializers.FeedingSerializer
     filterset_fields = ('child', 'type', 'method')
@@ -31,7 +32,7 @@ class NoteViewSet(viewsets.ModelViewSet):
     filterset_fields = ('child',)
 
 
-class SleepViewSet(viewsets.ModelViewSet):
+class SleepViewSet(TimerFieldSupportMixin, viewsets.ModelViewSet):
     queryset = models.Sleep.objects.all()
     serializer_class = serializers.SleepSerializer
     filterset_fields = ('child',)
@@ -49,7 +50,7 @@ class TimerViewSet(viewsets.ModelViewSet):
     filterset_fields = ('child', 'active', 'user')
 
 
-class TummyTimeViewSet(viewsets.ModelViewSet):
+class TummyTimeViewSet(TimerFieldSupportMixin, viewsets.ModelViewSet):
     queryset = models.TummyTime.objects.all()
     serializer_class = serializers.TummyTimeSerializer
     filterset_fields = ('child',)


### PR DESCRIPTION
Initial implementation for "timer" argument support in the API for models with duration (Feeding, Sleep, Tummy Time). Still needed:

- [x] New tests for all three models.
- [x] Custom information in the `OPTIONS` response.
- [x] Documentation updates.

Closes #131.