### PR TITLE
Auto select "bottle" method for formula and fortified milk types

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -50,7 +50,7 @@ def set_initial_values(kwargs, form_type):
         if last_feeding:
             last_type = last_feeding.type
             last_feed_args = {'type': last_feeding.type}
-            if last_type == 'formula':
+            if last_type in ['formula', 'fortified breast milk']:
                 last_feed_args['method'] = 'bottle'
             kwargs['initial'].update(last_feed_args)
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -43,12 +43,16 @@ def set_initial_values(kwargs, form_type):
             'end': timer.end or timezone.now()
         })
 
-    # Set initial type value for Feeding instance based on last type used.
+    # Set type and method values for Feeding instance based on last feed.
     if form_type == FeedingForm and 'child' in kwargs['initial']:
         last_feeding = models.Feeding.objects.filter(
             child=kwargs['initial']['child']).order_by('end').last()
         if last_feeding:
-            kwargs['initial'].update({'type': last_feeding.type})
+            last_type = last_feeding.type
+            last_feed_args = {'type': last_feeding.type}
+            if last_type == 'formula':
+                last_feed_args['method'] = 'bottle'
+            kwargs['initial'].update(last_feed_args)
 
     # Remove custom kwargs so they do not interfere with `super` calls.
     for key in ['child', 'timer']:

--- a/core/templates/core/feeding_form.html
+++ b/core/templates/core/feeding_form.html
@@ -35,5 +35,11 @@
             defaultDate: false
         });
         BabyBuddy.DatetimePicker.init($('#datetimepicker_end'));
+        $('#id_type').change(function() {
+            var feed_type=$('#id_type').val();
+            if (feed_type=='formula'||feed_type=='fortified breast milk') {
+                $('#id_method').val('bottle');
+            }
+        });
     </script>
 {% endblock %}

--- a/core/tests/tests_forms.py
+++ b/core/tests/tests_forms.py
@@ -93,7 +93,8 @@ class InitialValuesTestCase(FormsTestCaseBase):
             birth_date=timezone.localdate()
         )
         start_time = timezone.localtime() - timezone.timedelta(hours=4)
-        end_time = timezone.localtime() - timezone.timedelta(hours=3, minutes=30)
+        end_time = timezone.localtime() - timezone.timedelta(hours=3,
+                                                             minutes=30)
         f_one = models.Feeding.objects.create(
             child=self.child,
             start=start_time,
@@ -129,7 +130,8 @@ class InitialValuesTestCase(FormsTestCaseBase):
 
         page = self.c.get('/feedings/add/?child={}'.format(child_three.slug))
         self.assertEqual(page.context['form'].initial['type'], f_three.type)
-        self.assertEqual(page.context['form'].initial['method'], f_three.method)
+        self.assertEqual(page.context['form'].initial['method'],
+                         f_three.method)
 
     def test_timer_set(self):
         self.timer.stop()

--- a/core/tests/tests_forms.py
+++ b/core/tests/tests_forms.py
@@ -87,18 +87,32 @@ class InitialValuesTestCase(FormsTestCaseBase):
             last_name='Two',
             birth_date=timezone.localdate()
         )
+        child_three = models.Child.objects.create(
+            first_name='Child',
+            last_name='Three',
+            birth_date=timezone.localdate()
+        )
+        start_time = timezone.localtime() - timezone.timedelta(hours=4)
+        end_time = timezone.localtime() - timezone.timedelta(hours=3, minutes=30)
         f_one = models.Feeding.objects.create(
             child=self.child,
-            start=timezone.localtime() - timezone.timedelta(hours=4),
-            end=timezone.localtime() - timezone.timedelta(hours=3, minutes=30),
+            start=start_time,
+            end=end_time,
             type='breast milk',
             method='left breast'
         )
         f_two = models.Feeding.objects.create(
             child=child_two,
-            start=timezone.localtime() - timezone.timedelta(hours=4),
-            end=timezone.localtime() - timezone.timedelta(hours=3, minutes=30),
+            start=start_time,
+            end=end_time,
             type='formula',
+            method='bottle'
+        )
+        f_three = models.Feeding.objects.create(
+            child=child_three,
+            start=start_time,
+            end=end_time,
+            type='fortified breast milk',
             method='bottle'
         )
 
@@ -107,9 +121,15 @@ class InitialValuesTestCase(FormsTestCaseBase):
 
         page = self.c.get('/feedings/add/?child={}'.format(self.child.slug))
         self.assertEqual(page.context['form'].initial['type'], f_one.type)
+        self.assertFalse('method' in page.context['form'].initial)
 
         page = self.c.get('/feedings/add/?child={}'.format(child_two.slug))
         self.assertEqual(page.context['form'].initial['type'], f_two.type)
+        self.assertEqual(page.context['form'].initial['method'], f_two.method)
+
+        page = self.c.get('/feedings/add/?child={}'.format(child_three.slug))
+        self.assertEqual(page.context['form'].initial['type'], f_three.type)
+        self.assertEqual(page.context['form'].initial['method'], f_three.method)
 
     def test_timer_set(self):
         self.timer.stop()


### PR DESCRIPTION
Pre-populates the method select on the feeding form, and adds a function to the form to change the method select if formula or fortified milk are selected. I've made a couple of assumptions here, please correct me if they're wrong and I'll happily update the PR.

- Both "formula" and "fortified milk" are expected to only be fed by bottle.
- If breast milk is selected, it's best _not_ to pre-populate the method select. That just... feels like better UX to me.

Closes #127 .