### PR TITLE
Periodic session expiry update to prevent timeouts

### DIFF
--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -23,6 +23,7 @@ class UserTimezoneMiddleware:
                 pass
         return self.get_response(request)
 
+
 class RollingSessionMiddleware:
     """
     Periodically resets the session expiry.
@@ -35,7 +36,7 @@ class RollingSessionMiddleware:
         if session_refresh:
             try:
                 delta = int(time.time()) - session_refresh
-            except:
+            except (ValueError, TypeError):
                 delta = settings.ROLLING_SESSION_REFRESH + 1
             if delta > settings.ROLLING_SESSION_REFRESH:
                 request.session['session_refresh'] = int(time.time())

--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -1,5 +1,8 @@
+import time
+
 import pytz
 
+from django.conf import settings
 from django.utils import timezone
 
 
@@ -18,4 +21,25 @@ class UserTimezoneMiddleware:
                 timezone.activate(pytz.timezone(timezone_name))
             except pytz.UnknownTimeZoneError:
                 pass
+        return self.get_response(request)
+
+class RollingSessionMiddleware:
+    """
+    Periodically resets the session expiry.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        session_refresh = request.session.get('session_refresh')
+        if session_refresh:
+            try:
+                delta = int(time.time()) - session_refresh
+            except:
+                delta = settings.ROLLING_SESSION_REFRESH + 1
+            if delta > settings.ROLLING_SESSION_REFRESH:
+                request.session['session_refresh'] = int(time.time())
+                request.session.set_expiry(settings.SESSION_COOKIE_AGE)
+        else:
+            request.session['session_refresh'] = int(time.time())
         return self.get_response(request)

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -58,6 +58,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'babybuddy.middleware.RollingSessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'babybuddy.middleware.UserTimezoneMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -222,6 +223,10 @@ REST_FRAMEWORK = {
 IMPORT_EXPORT_IMPORT_PERMISSION_CODE = 'add'
 IMPORT_EXPORT_EXPORT_PERMISSION_CODE = 'change'
 IMPORT_EXPORT_USE_TRANSACTIONS = True
+
+# Rolling session refreshes
+# How often to refresh the session
+ROLLING_SESSION_REFRESH = 86400
 
 # Baby Buddy configuration
 # See README.md#configuration for details about these settings.

--- a/babybuddy/settings/development.py
+++ b/babybuddy/settings/development.py
@@ -35,3 +35,5 @@ REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = (
     'rest_framework.renderers.JSONRenderer',
     'rest_framework.renderers.BrowsableAPIRenderer',
 )
+
+ROLLING_SESSION_REFRESH = 1

--- a/babybuddy/tests/tests_views.py
+++ b/babybuddy/tests/tests_views.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import time
+
 from django.test import TestCase
 from django.test import Client as HttpClient
 from django.contrib.auth.models import User
@@ -29,6 +31,19 @@ class ViewsTestCase(TestCase):
     def test_root_router(self):
         page = self.c.get('/')
         self.assertEqual(page.url, '/dashboard/')
+
+    def test_rolling_sessions(self):
+        self.c.get('/')
+        session1 = str(self.c.cookies['sessionid'])
+        # Sleep longer than ROLLING_SESSION_REFRESH in our
+        # settings module, to test we get a new session.
+        time.sleep(2)
+        self.c.get('/')
+        session2 = str(self.c.cookies['sessionid'])
+        self.c.get('/')
+        session3 = str(self.c.cookies['sessionid'])
+        self.assertNotEqual(session1, session2)
+        self.assertEqual(session2, session3)
 
     def test_user_reset_api_key(self):
         api_key_before = User.objects.get(pk=self.user.id).settings.api_key()


### PR DESCRIPTION
I did some experimentation using the `SESSION_SAVE_EVERY_REQUEST` setting, which does indeed end up updating the expiry on the sessionid cookie with every request. But quickly realised that saving the session on every request also means adding a write to the database to every request. I suppose it doesn't really matter for a small app like this, but that just didn't seem very efficient, so I thought I'd try to save it less frequently.

This PR adds new middleware that checks when the session was last updated, and resets the expiry at configurable periods, with a default of 24 hours. It does this by setting a timestamp in the user's session.