### PR TITLE
Ensure date passed to nap filter is localtime.

### DIFF
--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -148,8 +148,9 @@ def card_sleep_naps_day(child, date=None):
     :param date: a Date object for the day to filter.
     :returns: a dictionary of nap data statistics.
     """
-    date = timezone.localtime(date).astimezone(timezone.utc)
-    instances = models.Sleep.naps.filter(child=child, start__date=date.date())
+    if not date:
+        date = timezone.localtime().date()
+    instances = models.Sleep.naps.filter(child=child, start__date=date)
     return {
         'type': 'sleep',
         'total': instances.aggregate(Sum('duration'))['duration__sum'],


### PR DESCRIPTION
The nap card was taking a UTC date and passing it to the filter without TZ information, so it was being interpreted as a localtime date. This PR changes the card to use the same date lookup method as other cards that need it (Today's Sleep, Today's Tummy Time).

But this is a code path that a few dashboard cards use, and it isn't really being tested. I'm not sure how to properly test it either, short of mocking `timezone.localtime()`.

Closes #136 