### PR TITLE
Add a "Today's Feeding" card

### DIFF
--- a/dashboard/templates/cards/feeding_day.html
+++ b/dashboard/templates/cards/feeding_day.html
@@ -1,0 +1,18 @@
+{% extends 'cards/base.html' %}
+{% load duration i18n %}
+
+{% block header %}{% trans "Today's Feeding" %}{% endblock %}
+
+{% block title %}
+    {% if total %}
+        {{ total }}
+    {% else %}
+        {% trans "None" %}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    {% if count > 0 %}
+        {% blocktrans %}{{ count }} feeding entries{% endblocktrans %}
+    {% endif %}
+{% endblock %}

--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -13,6 +13,7 @@
     <div id="dashboard-child" class="card-columns">
         {% card_feeding_last object %}
         {% card_feeding_last_method object %}
+        {% card_feeding_day object %}
         {% card_timer_list object %}
         {% card_statistics object %}
         {% card_sleep_last object %}

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -68,6 +68,31 @@ def card_diaperchange_types(child, date=None):
     return {'type': 'diaperchange', 'stats': stats, 'total': week_total}
 
 
+@register.inclusion_tag('cards/feeding_day.html')
+def card_feeding_day(child, date=None):
+    """
+    Filters Feeding instances to get total amount for a specific date.
+    :param child: an instance of the Child model.
+    :param date: a Date object for the day to filter.
+    :returns: a dict with count and total amount for the Feeding instances.
+    """
+    if not date:
+        date = timezone.localtime().date()
+    instances = models.Feeding.objects.filter(child=child).filter(
+        start__year=date.year,
+        start__month=date.month,
+        start__day=date.day) \
+        | models.Feeding.objects.filter(child=child).filter(
+        end__year=date.year,
+        end__month=date.month,
+        end__day=date.day)
+
+    total = sum([instance.amount for instance in instances if instance.amount])
+    count = len(instances)
+
+    return {'type': 'feeding', 'total': total, 'count': count}
+
+
 @register.inclusion_tag('cards/feeding_last.html')
 def card_feeding_last(child):
     """

--- a/dashboard/tests/tests_templatetags.py
+++ b/dashboard/tests/tests_templatetags.py
@@ -46,6 +46,12 @@ class TemplateTagsTestCase(TestCase):
         }
         self.assertEqual(data['stats'], stats)
 
+    def test_card_feeding_day(self):
+        data = cards.card_feeding_day(self.child, self.date)
+        self.assertEqual(data['type'], 'feeding')
+        self.assertEqual(data['total'], 2.5)
+        self.assertEqual(data['count'], 3)
+
     def test_card_feeding_last(self):
         data = cards.card_feeding_last(self.child)
         self.assertEqual(data['type'], 'feeding')


### PR DESCRIPTION
It is useful to know today's cumulated Feeding amount.

Right now, this can be inferred from the "Feeding Amount" report,
but is not made readily available in the dashboard, where the
Feeding-related cards are the last Feeding and its method.

This adds a new card `Today's Feeding`, heavily based on "Today's Sleep".