### PR TITLE
Use correct Python versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 os: linux
 language: generic
-dist: focal
+dist: bionic
 jobs:
   include:
     - name: "Python 3.6"
       before_install:
-        - unset PYENV_ROOT
-        - curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-        - export PATH="$HOME/.pyenv/bin:$PATH"
-        - pyenv versions
-        - pyenv install --list
-        - pyenv install 3.6.10
         - pyenv versions
         - pyenv global 3.6.10
         - pyenv versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ jobs:
         - pyenv versions
         - pyenv install --list
         - pyenv install 3.6.10
+        - pyenv versions
         - pyenv global 3.6.10
+        - pyenv versions
     - name: "Python 3.7"
       before_install:
         - pyenv global 3.7.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: linux
 language: generic
-dist: bionic
+dist: focal
 jobs:
   include:
     - name: "Python 3.6"
@@ -19,7 +19,7 @@ cache:
 env:
   - DJANGO_SETTINGS_MODULE="babybuddy.settings.travis"
 install:
-  - nvm use 10
+  - nvm use 12
   - npm install -g gulp-cli
   - npm install
   - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ jobs:
     - name: "Python 3.6"
       before_install:
         - pyenv global `pyenv versions | tr -d "[:blank:]" | grep -Po "3\.6\.[\d]+" | tail -1`
+        - rm Pipfile.lock
     - name: "Python 3.7"
       before_install:
         - pyenv global `pyenv versions | tr -d "[:blank:]" | grep -Po "3\.7\.[\d]+" | tail -1`
+        - rm Pipfile.lock
     - name: "Python 3.8"
       before_install:
         - pyenv global `pyenv versions | tr -d "[:blank:]" | grep -Po "3\.8\.[\d]+" | tail -1`

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ jobs:
   include:
     - name: "Python 3.6"
       before_install:
-        - pyenv versions
-        - pyenv global 3.6.10
-        - pyenv versions
+        - pyenv global `pyenv versions | tr -d "[:blank:]" | grep -Po "3\.6\.[\d]+" | tail -1`
     - name: "Python 3.7"
       before_install:
-        - pyenv global 3.7.6
+        - pyenv global `pyenv versions | tr -d "[:blank:]" | grep -Po "3\.7\.[\d]+" | tail -1`
     - name: "Python 3.8"
       before_install:
-        - pyenv global 3.8.1
+        - pyenv global `pyenv versions | tr -d "[:blank:]" | grep -Po "3\.8\.[\d]+" | tail -1`
 cache:
   directories:
     - $HOME/.cache/pip
@@ -21,11 +19,11 @@ cache:
 env:
   - DJANGO_SETTINGS_MODULE="babybuddy.settings.travis"
 install:
-  - nvm use 12
+  - nvm use 10
   - npm install -g gulp-cli
   - npm install
   - pip install pipenv
-  - pipenv install --dev
+  - pipenv --python `pyenv which python` install --dev
 before_script:
   - gulp lint
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ jobs:
   include:
     - name: "Python 3.6"
       before_install:
-        - pyenv update
+        - unset PYENV_ROOT
+        - curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+        - export PATH="$HOME/.pyenv/bin:$PATH"
         - pyenv versions
         - pyenv install --list
+        - pyenv install 3.6.10
         - pyenv global 3.6.10
     - name: "Python 3.7"
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ jobs:
   include:
     - name: "Python 3.6"
       before_install:
+        - pyenv versions
+        - pyenv install --list
         - pyenv global 3.6.10
     - name: "Python 3.7"
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jobs:
   include:
     - name: "Python 3.6"
       before_install:
+        - pyenv update
         - pyenv versions
         - pyenv install --list
         - pyenv global 3.6.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-[![Build Status](https://travis-ci.org/babybuddy/babybuddy.svg?branch=master)](https://travis-ci.org/babybuddy/babybuddy)
+[![Build Status](https://travis-ci.org/babybuddy/babybuddy.svg?branch=master)](https://travis-ci.com/babybuddy/babybuddy)
 [![Coverage Status](https://coveralls.io/repos/github/babybuddy/babybuddy/badge.svg?branch=master)](https://coveralls.io/github/babybuddy/babybuddy?branch=master)
 
 - [Contributions](#contributions)


### PR DESCRIPTION
Fixing this reveals that Python 3.6 actually is _not_ supported now because of a recent commit that uses [`datetime.date.fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat).

Closes #158 