### PR TITLE
Fixed duplicate data/form-submit from double click

### DIFF
--- a/babybuddy/static_src/js/babybuddy.js
+++ b/babybuddy/static_src/js/babybuddy.js
@@ -59,3 +59,10 @@ BabyBuddy.PullToRefresh = function(ptr) {
         }
     };
 }(PullToRefresh);
+
+/**
+ * Fix for duplicate form submission from double pressing submit
+ */
+$("form").on("submit", function() {
+    $(this).find("button[type='submit']").prop('disabled', true);
+});

--- a/static/babybuddy/js/app.d2994702ae86.js
+++ b/static/babybuddy/js/app.d2994702ae86.js
@@ -60,6 +60,13 @@ BabyBuddy.PullToRefresh = function(ptr) {
     };
 }(PullToRefresh);
 
+/**
+ * Fix for duplicate form submission from double pressing submit
+ */
+$("form").on("submit", function() {
+    $(this).find("button[type='submit']").prop('disabled', true);
+});
+
 /* Baby Buddy Timer
  *
  * Uses a supplied ID to run a timer. The element using the ID must have

--- a/static/babybuddy/js/app.js
+++ b/static/babybuddy/js/app.js
@@ -60,6 +60,13 @@ BabyBuddy.PullToRefresh = function(ptr) {
     };
 }(PullToRefresh);
 
+/**
+ * Fix for duplicate form submission from double pressing submit
+ */
+$("form").on("submit", function() {
+    $(this).find("button[type='submit']").prop('disabled', true);
+});
+
 /* Baby Buddy Timer
  *
  * Uses a supplied ID to run a timer. The element using the ID must have


### PR DESCRIPTION
Reproduce:
When clicking the submit on any form in the web app, multiple times very fast, it creates duplicate entries / actions.

Anecdote:
We used this app for our first child, which recently turned 1! I am participating in Hacktoberfest this year, and I remember that my wife's biggest complaint was the creation of multiple entries. I had the app running in docker on a low powered machine, so it would take a while to hit the api / store the data. So she would be impatient and kept clicking submit because it didn't look like it was doing anything, thus creating duplicate entries.

Fix:
Anyways, I added code to disable he submit buttons upon first click. Hopefully this will be a helpful change for anyone else who may have the same setup as I did.

PS:
Also, if you could add **hacktoberfest-accepted** label to this pull-request it would be greatly appreciated!
Thanks for this very cool project!