### PR TITLE
Updates to docker compose files for Portainer compatibility

### DIFF
--- a/docker-compose.example.sqlite.yml
+++ b/docker-compose.example.sqlite.yml
@@ -20,6 +20,7 @@ services:
       - "8000:8000"
     # For Portainer deployment, select an alternate port for babybuddy, such as port 7000
     # - "7000:8000"
+    restart: unless-stopped
 volumes:
   data: {}
   media: {}

--- a/docker-compose.example.sqlite.yml
+++ b/docker-compose.example.sqlite.yml
@@ -4,7 +4,7 @@ services:
     image: babybuddy/babybuddy
     # Container_name is an optional value for single-container deployments to set a friendly container name.
     # Disable in swarm or other multi-container setups.
-    container_name: babybuddy
+    container_name: babybuddyapp
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=localhost   # comma separated list of IP addresses or hosts that can access the web UI
@@ -17,9 +17,7 @@ services:
       - media:/app/media:rw
     command: bash -c 'python manage.py migrate --noinput && python manage.py createcachetable && gunicorn babybuddy.wsgi -b :8000 --log-level=info'
     ports:
-      - "8000:8000"
-    # For Portainer deployment, select an alternate port for babybuddy, such as port 7000
-    # - "7000:8000"
+      - "8000:8000" # For Portainer, select an alternate port for babybuddy, such as 7000, for example "7000:8000"
     restart: unless-stopped
 volumes:
   data: {}

--- a/docker-compose.example.sqlite.yml
+++ b/docker-compose.example.sqlite.yml
@@ -2,9 +2,9 @@ version: "2.4"
 services:
   app:
     image: babybuddy/babybuddy
-    # Container_name is an optional value for single-container deployments to set a friendly container name.
-    # Disable in swarm or other multi-container setups.
-    container_name: babybuddyapp
+    container_name: babybuddyapp   # Container_name is an optional value for single-container
+                                   # deployments to set a friendly container name.
+                                   # Disable in swarm or other multi-container setups.
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=localhost   # comma separated list of IP addresses or hosts that can access the web UI
@@ -17,7 +17,7 @@ services:
       - media:/app/media:rw
     command: bash -c 'python manage.py migrate --noinput && python manage.py createcachetable && gunicorn babybuddy.wsgi -b :8000 --log-level=info'
     ports:
-      - "8000:8000" # For Portainer, select an alternate port for babybuddy, such as 7000, for example "7000:8000"
+      - "8000:8000"               # For Portainer, select another port for babybuddy such as 7000, for example "7000:8000"
     restart: unless-stopped
 volumes:
   data: {}

--- a/docker-compose.example.sqlite.yml
+++ b/docker-compose.example.sqlite.yml
@@ -1,20 +1,25 @@
-version: "3.7"
+version: "2.4"
 services:
   app:
     image: babybuddy/babybuddy
+    # Container_name is an optional value for single-container deployments to set a friendly container name.
+    # Disable in swarm or other multi-container setups.
+    container_name: babybuddy
     # See README.md#configuration for other environment configuration options.
     environment:
-      - ALLOWED_HOSTS=
+      - ALLOWED_HOSTS=localhost   # comma separated list of IP addresses or hosts that can access the web UI
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.base
-      - SECRET_KEY=
-      - TIME_ZONE=
-      - DEBUG=False # Turn to False in production
+      - SECRET_KEY=               # Generate a random string here to secure the Django instance
+      - TIME_ZONE=                # In the tzdata format, IE, "America/Denver"
+      - DEBUG=False               # Turn to False in production
     volumes:
       - data:/app/data:rw
       - media:/app/media:rw
     command: bash -c 'python manage.py migrate --noinput && python manage.py createcachetable && gunicorn babybuddy.wsgi -b :8000 --log-level=info'
     ports:
       - "8000:8000"
+    # For Portainer deployment, select an alternate port for babybuddy, such as port 7000
+    # - "7000:8000"
 volumes:
   data: {}
   media: {}

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -29,7 +29,7 @@ services:
     # Sleep 5 seconds to allow the db to to come up;
     command: bash -c 'sleep 5 && python manage.py migrate --noinput && python manage.py createcachetable && gunicorn babybuddy.wsgi -b :8000 --log-level=info'
     ports:
-      - "8000:8000" # For Portainer, select an alternate port for babybuddy, such as 7000, for example "7000:8000"
+      - "8000:8000"               # For Portainer, select another port for babybuddy such as 7000, for example "7000:8000"
     restart: unless-stopped
     depends_on:
       - db

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,21 +1,21 @@
 version: "2.4"
 services:
   db:
-    image: postgres:11 # pin postgres to a major version
-    # Container_name is an optional value for single-container deployments to set a friendly container name.
-    # Disable in swarm or other multi-container setups.
-    container_name: babybuddydb
+    image: postgres:11             # pin postgres to a major version
+    container_name: babybuddydb    # Container_name is an optional value for single-container
+                                   # deployments to set a friendly container name.
+                                   # Disable in swarm or other multi-container setups.
     environment:
       - PGDATA=/db-data
-      - POSTGRES_PASSWORD=postgres # has to correspond with DB_PASSWORD in APP
+      - POSTGRES_PASSWORD=postgres # must correspond with DB_PASSWORD in APP
     volumes:
       - db:/db-data:rw
     restart: unless-stopped
   app:
     image: babybuddy/babybuddy
-    # Container_name is an optional value for single-container deployments to set a friendly container name.
-    # Disable in swarm or other multi-container setups.
-    container_name: babybuddyapp
+    container_name: babybuddyapp   # Container_name is an optional value for single-container
+                                   # deployments to set a friendly container name.
+                                   # Disable in swarm or other multi-container setups.
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=localhost    # comma separated list of IP addresses or hosts that can access the web UI

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -15,23 +15,21 @@ services:
     image: babybuddy/babybuddy
     # Container_name is an optional value for single-container deployments to set a friendly container name.
     # Disable in swarm or other multi-container setups.
-    container_name: babybuddy
+    container_name: babybuddyapp
     # See README.md#configuration for other environment configuration options.
     environment:
-      - ALLOWED_HOSTS=localhost   # comma separated list of IP addresses or hosts that can access the web UI
+      - ALLOWED_HOSTS=localhost    # comma separated list of IP addresses or hosts that can access the web UI
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.docker
-      - SECRET_KEY=               # Generate a random string here to secure the Django instance
-      - TIME_ZONE=                # In the tzdata format, IE, "America/Denver"
+      - SECRET_KEY=                # Generate a random string here to secure the Django instance
+      - TIME_ZONE=                 # In the tzdata format, IE, "America/Denver"
       - POSTGRES_PASSWORD=postgres # has to correspond with DB_PASSWORD in DB
-      - DEBUG=False               # Turn to False in production
+      - DEBUG=False                # Turn to False in production
     volumes:
       - media:/app/media:rw
     # Sleep 5 seconds to allow the db to to come up;
     command: bash -c 'sleep 5 && python manage.py migrate --noinput && python manage.py createcachetable && gunicorn babybuddy.wsgi -b :8000 --log-level=info'
     ports:
-      - "8000:8000"
-    # For Portainer deployment, select an alternate port for babybuddy, such as port 7000
-    # - "7000:8000"
+      - "8000:8000" # For Portainer, select an alternate port for babybuddy, such as 7000, for example "7000:8000"
     restart: unless-stopped
     depends_on:
       - db

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,28 +1,38 @@
-version: "3.7"
+version: "2.4"
 services:
   db:
     image: postgres:11 # pin postgres to a major version
+    # Container_name is an optional value for single-container deployments to set a friendly container name.
+    # Disable in swarm or other multi-container setups.
+    container_name: babybuddydb
     environment:
       - PGDATA=/db-data
       - POSTGRES_PASSWORD=postgres # has to correspond with POSTGRES_PASSWORD in APP
     volumes:
       - db:/db-data:rw
+    restart: unless-stopped
   app:
     image: babybuddy/babybuddy
+    # Container_name is an optional value for single-container deployments to set a friendly container name.
+    # Disable in swarm or other multi-container setups.
+    container_name: babybuddy
     # See README.md#configuration for other environment configuration options.
     environment:
-      - ALLOWED_HOSTS=
+      - ALLOWED_HOSTS=localhost   # comma separated list of IP addresses or hosts that can access the web UI
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.docker
-      - SECRET_KEY=
-      - TIME_ZONE=
+      - SECRET_KEY=               # Generate a random string here to secure the Django instance
+      - TIME_ZONE=                # In the tzdata format, IE, "America/Denver"
       - POSTGRES_PASSWORD=postgres
-      - DEBUG=False # Turn to False in production
+      - DEBUG=False               # Turn to False in production
     volumes:
       - media:/app/media:rw
     # Sleep 5 seconds to allow the db to to come up;
     command: bash -c 'sleep 5 && python manage.py migrate --noinput && python manage.py createcachetable && gunicorn babybuddy.wsgi -b :8000 --log-level=info'
     ports:
       - "8000:8000"
+    # For Portainer deployment, select an alternate port for babybuddy, such as port 7000
+    # - "7000:8000"
+    restart: unless-stopped
     depends_on:
       - db
 volumes:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -19,10 +19,10 @@ services:
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=localhost    # comma separated list of IP addresses or hosts that can access the web UI
+      - DB_PASSWORD=postgres       # must correspond with POSTGRES_PASSWORD in DB
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.docker
       - SECRET_KEY=                # Generate a random string here to secure the Django instance
       - TIME_ZONE=                 # In the tzdata format, IE, "America/Denver"
-      - POSTGRES_PASSWORD=postgres # has to correspond with DB_PASSWORD in DB
       - DEBUG=False                # Turn to False in production
     volumes:
       - media:/app/media:rw


### PR DESCRIPTION
Hi, this pull request is not 100% ready - I'm still a github novice so I'm probably doing something wrong with my commits.

The changes to `docker-compose.example.sqlite.yml` are good, and tested in Portainer. I dropped to the earliest compatible compose version (2.4), added some notes, and a friendly container name. This addresses issue: https://github.com/babybuddy/babybuddy/issues/165

The changes to `docker-compose.example.yml` are NOT working in Portainer, and I'm not sure why. The startup script appears to be looking for a service at hostname "db", but the hostname will either be generated from the stack "babybuddy_db_1" or from the container_name "babybuddydb".

I'm not sure how to separate the commits (again, quite novice at this part), but at least the first part appears to be good, and shouldn't cause any breaking changes with standard compose deployments.