### PR TITLE
Allow for custom PostgreSQL Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,12 @@ take precedence over the contents of an `.env` file.**
 - [`DEBUG`](#debug)
 - [`NAP_START_MAX`](#nap_start_max)
 - [`NAP_START_MIN`](#nap_start_min)
-- [`POSTGRES_DB`](#postgres_db)
-- [`POSTGRES_HOST`](#postgres_host)
-- [`POSTGRES_PASSWORD`](#postgres_password)
-- [`POSTGRES_PORT`](#postgres_port)
-- [`POSTGRES_USER`](#postgres_user)
+- [`DB_ENGINE`](#db_engine)
+- [`DB_HOST`](#db_host)
+- ['DB_NAME'](#db_name)
+- [`DB_PASSWORD`](#db_password)
+- [`DB_PORT`](#db_port)
+- [`DB_USER`](#db_user)
 - [`SECRET_KEY`](#secret_key)
 - [`TIME_ZONE`](#time_zone)
 - [`USE_24_HOUR_TIME_FORMAT`](#use_24_hour_time_format)
@@ -359,35 +360,43 @@ entry is consider a nap. Expects the 24-hour format %H:%M.
 The minimum *start* time (in the instance's time zone) after which a sleep
 entry is considered a nap. Expects the 24-hour format %H:%M.
 
-### 'POSTGRES_DB'
+### 'DB_ENGINE'
 
-*Default: postgres*
+*Default: django.db.backends.postgresql*
 
-The name of the PostgreSQL table Baby Buddy will utilize.
+The database engine utilized for the deployment.
 
-### 'POSTGRES_HOST'
+See also [Django's documentation on the ENGINE setting](https://docs.djangoproject.com/en/3.0/ref/settings/#engine) .
+
+### 'DB_HOST'
 
 *Default: db*
 
-The name of the PostgreSQL host.
+The name of the database host for the deployment.
 
-### 'POSTGRES_PASSWORD'
-
-*No Default*
-
-The password for the PostgreSQL user used to connect to PostgreSQL. In the default example, this is the root PostgreSQL password.
-
-### 'POSTGRES_PORT'
-
-*Default: 5432*
-
-The port PostgreSQL listens on if not the default 5432.
-
-### 'POSTGRES_USER'
+### 'DB_NAME'
 
 *Default: postgres*
 
-The username Baby Buddy will use to connect to the PostgreSQL database.
+The name of the database table utilized for the deployment.
+
+### 'DB_PASSWORD'
+
+*No Default*
+
+The password for the database user for the deployment. In the default example, this is the root PostgreSQL password.
+
+### 'DB_PORT'
+
+*Default: 5432*
+
+The listening port for the database. The default port is 5432 for PostgreSQL.
+
+### 'DB_USER'
+
+*Default: postgres*
+
+The database username utilized for the deployment.
 
 ### `SECRET_KEY`
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,11 @@ take precedence over the contents of an `.env` file.**
 - [`DEBUG`](#debug)
 - [`NAP_START_MAX`](#nap_start_max)
 - [`NAP_START_MIN`](#nap_start_min)
+- [`POSTGRES_DB`](#postgres_db)
+- [`POSTGRES_HOST`](#postgres_host)
+- [`POSTGRES_PASSWORD`](#postgres_password)
+- [`POSTGRES_PORT`](#postgres_port)
+- [`POSTGRES_USER`](#postgres_user)
 - [`SECRET_KEY`](#secret_key)
 - [`TIME_ZONE`](#time_zone)
 - [`USE_24_HOUR_TIME_FORMAT`](#use_24_hour_time_format)
@@ -353,6 +358,36 @@ entry is consider a nap. Expects the 24-hour format %H:%M.
 
 The minimum *start* time (in the instance's time zone) after which a sleep
 entry is considered a nap. Expects the 24-hour format %H:%M.
+
+### 'POSTGRES_DB'
+
+*Default: postgres*
+
+The name of the PostgreSQL table Baby Buddy will utilize.
+
+### 'POSTGRES_HOST'
+
+*Default: db*
+
+The name of the PostgreSQL host.
+
+### 'POSTGRES_PASSWORD'
+
+*No Default*
+
+The password for the PostgreSQL user used to connect to PostgreSQL. In the default example, this is the root PostgreSQL password.
+
+### 'POSTGRES_PORT'
+
+*Default: 5432*
+
+The port PostgreSQL listens on if not the default 5432.
+
+### 'POSTGRES_USER'
+
+*Default: postgres*
+
+The username Baby Buddy will use to connect to the PostgreSQL database.
 
 ### `SECRET_KEY`
 

--- a/babybuddy/settings/docker.py
+++ b/babybuddy/settings/docker.py
@@ -10,7 +10,7 @@ DATABASES = {
         'ENGINE': os.getenv('DB_ENGINE') or 'django.db.backends.postgresql_psycopg2',
         'NAME': os.getenv('DB_NAME') or 'postgres',
         'USER': os.getenv('DB_USER') or 'postgres',
-        'PASSWORD': os.environ.get('DB_PASSWORD'),
+        'PASSWORD': os.environ.get('DB_PASSWORD') or os.environ.get('POSTGRES_PASSWORD'),
         'HOST': os.getenv('DB_HOST') or 'db',
         'PORT': os.getenv('DB_PORT') or 5432,
     }

--- a/babybuddy/settings/docker.py
+++ b/babybuddy/settings/docker.py
@@ -7,11 +7,11 @@ from .base import *
 # Load settings from env file / variables with fallback defaults to support current psql deployment
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': os.getenv('POSTGRES_DB') if os.getenv('POSTGRES_DB') else 'postgres',
-        'USER': os.getenv('POSTGRES_USER') if os.getenv('POSTGRES_USER') else 'postgres',
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-        'HOST': os.getenv('POSTGRES_HOST') if os.getenv('POSTGRES_HOST') else 'db',
-        'PORT': os.getenv('POSTGRES_PORT') if os.getenv('POSTGRES_PORT') else 5432,
+        'ENGINE': os.getenv('DB_ENGINE') or 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.getenv('DB_NAME') or 'postgres',
+        'USER': os.getenv('DB_USER') or 'postgres',
+        'PASSWORD': os.environ.get('DB_PASSWORD'),
+        'HOST': os.getenv('DB_HOST') or 'db',
+        'PORT': os.getenv('DB_PORT') or 5432,
     }
 }

--- a/babybuddy/settings/docker.py
+++ b/babybuddy/settings/docker.py
@@ -4,13 +4,14 @@ from .base import *
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 
+# Load settings from env file / variables with fallback defaults to support current psql deployment
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'postgres',
-        'USER': 'postgres',
+        'NAME': os.getenv('POSTGRES_DB') if os.getenv('POSTGRES_DB') else 'postgres',
+        'USER': os.getenv('POSTGRES_USER') if os.getenv('POSTGRES_USER') else 'postgres',
         'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-        'HOST': 'db',
-        'PORT': 5432,
+        'HOST': os.getenv('POSTGRES_HOST') if os.getenv('POSTGRES_HOST') else 'db',
+        'PORT': os.getenv('POSTGRES_PORT') if os.getenv('POSTGRES_PORT') else 5432,
     }
 }

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -12,12 +12,7 @@ services:
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=
-      - DB_ENGINE=django.db.backends.postgresql_psycopg2
-      - DB_HOST=
-      - DB_NAME=
       - DB_PASSWORD=postgres # has to correspond with POSTGRES_PASSWORD in DB
-      - DB_PORT=
-      - DB_NAME=
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.docker
       - SECRET_KEY=
       - TIME_ZONE=

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:11 # pin postgres to a major version
     environment:
       - PGDATA=/db-data
-      - POSTGRES_PASSWORD=postgres # has to correspond with POSTGRES_PASSWORD in APP
+      - POSTGRES_PASSWORD=postgres # has to correspond with DB_PASSWORD in APP
     volumes:
       - db:/db-data:rw
   app:
@@ -12,10 +12,15 @@ services:
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=
+      - DB_ENGINE=django.db.backends.postgresql
+      - DB_HOST=db
+      - DB_NAME=postgres
+      - DB_PASSWORD=postgres # has to correspond with POSTGRES_PASSWORD in DB
+      - DB_PORT=5432
+      - DB_NAME=postgres
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.docker
       - SECRET_KEY=
       - TIME_ZONE=
-      - POSTGRES_PASSWORD=postgres
       - DEBUG=False # Turn to False in production
     volumes:
       - media:/app/media:rw

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -12,12 +12,12 @@ services:
     # See README.md#configuration for other environment configuration options.
     environment:
       - ALLOWED_HOSTS=
-      - DB_ENGINE=django.db.backends.postgresql
-      - DB_HOST=db
-      - DB_NAME=postgres
+      - DB_ENGINE=django.db.backends.postgresql_psycopg2
+      - DB_HOST=
+      - DB_NAME=
       - DB_PASSWORD=postgres # has to correspond with POSTGRES_PASSWORD in DB
-      - DB_PORT=5432
-      - DB_NAME=postgres
+      - DB_PORT=
+      - DB_NAME=
       - DJANGO_SETTINGS_MODULE=babybuddy.settings.docker
       - SECRET_KEY=
       - TIME_ZONE=


### PR DESCRIPTION
Fixes issue #180 by allowing for any of the new PostgreSQL variables to be defined by user or fallback to expected defaults from existing deployment examples.