### PR TITLE
child slugs: Require non-blank, preserve unicode letters

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from django.utils import timezone
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
@@ -80,6 +80,7 @@ class Child(models.Model):
         verbose_name=_('Birth date')
     )
     slug = models.SlugField(
+        allow_unicode=True,
         blank=False,
         editable=False,
         max_length=100,
@@ -107,7 +108,7 @@ class Child(models.Model):
         return '{} {}'.format(self.first_name, self.last_name)
 
     def save(self, *args, **kwargs):
-        self.slug = slugify(self)
+        self.slug = slugify(self, allow_unicode=True)
         super(Child, self).save(*args, **kwargs)
         cache.set(self.cache_key_count, Child.objects.count(), None)
 

--- a/core/models.py
+++ b/core/models.py
@@ -80,6 +80,7 @@ class Child(models.Model):
         verbose_name=_('Birth date')
     )
     slug = models.SlugField(
+        blank=False,
         editable=False,
         max_length=100,
         unique=True,

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,14 +8,14 @@ app_name = 'core'
 urlpatterns = [
     path('children/', views.ChildList.as_view(), name='child-list'),
     path('children/add/', views.ChildAdd.as_view(), name='child-add'),
-    path('children/<slug:slug>/', views.ChildDetail.as_view(), name='child'),
+    path('children/<str:slug>/', views.ChildDetail.as_view(), name='child'),
     path(
-        'children/<slug:slug>/edit/',
+        'children/<str:slug>/edit/',
         views.ChildUpdate.as_view(),
         name='child-update'
     ),
     path(
-        'children/<slug:slug>/delete/',
+        'children/<str:slug>/delete/',
         views.ChildDelete.as_view(),
         name='child-delete'
     ),

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -8,7 +8,7 @@ app_name = 'dashboard'
 urlpatterns = [
     path('dashboard/', views.Dashboard.as_view(), name='dashboard'),
     path(
-        'children/<slug:slug>/dashboard/',
+        'children/<str:slug>/dashboard/',
         views.ChildDashboard.as_view(),
         name='dashboard-child'
     ),

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -7,42 +7,42 @@ app_name = 'reports'
 
 urlpatterns = [
     path(
-        'children/<slug:slug>/reports/changes/amounts/',
+        'children/<str:slug>/reports/changes/amounts/',
         views.DiaperChangeAmounts.as_view(),
         name='report-diaperchange-amounts-child'
     ),
     path(
-        'children/<slug:slug>/reports/changes/lifetimes/',
+        'children/<str:slug>/reports/changes/lifetimes/',
         views.DiaperChangeLifetimesChildReport.as_view(),
         name='report-diaperchange-lifetimes-child'
     ),
     path(
-        'children/<slug:slug>/reports/changes/types/',
+        'children/<str:slug>/reports/changes/types/',
         views.DiaperChangeTypesChildReport.as_view(),
         name='report-diaperchange-types-child'
     ),
     path(
-        'children/<slug:slug>/reports/feeding/amounts/',
+        'children/<str:slug>/reports/feeding/amounts/',
         views.FeedingAmountsChildReport.as_view(),
         name='report-feeding-amounts-child'
     ),
     path(
-        'children/<slug:slug>/reports/feeding/duration/',
+        'children/<str:slug>/reports/feeding/duration/',
         views.FeedingDurationChildReport.as_view(),
         name='report-feeding-duration-child'
     ),
     path(
-        'children/<slug:slug>/reports/sleep/pattern/',
+        'children/<str:slug>/reports/sleep/pattern/',
         views.SleepPatternChildReport.as_view(),
         name='report-sleep-pattern-child'
     ),
     path(
-        'children/<slug:slug>/reports/sleep/totals/',
+        'children/<str:slug>/reports/sleep/totals/',
         views.SleepTotalsChildReport.as_view(),
         name='report-sleep-totals-child'
     ),
     path(
-        'children/<slug:slug>/reports/weight/weight/',
+        'children/<str:slug>/reports/weight/weight/',
         views.WeightWeightChildReport.as_view(),
         name='report-weight-weight-child'
     ),


### PR DESCRIPTION
Will prevent #205 from happening in future.  
`'Мааян' 'Паскин-Чернявский'` => slug `'мааян-паскин-чернявский'` :+1:  
This results in %-encoded URLs, but modern browsers display the unicode chars (e.g. https://babybuddy.../children/мааян-паскин-чернявский).

Does not fix existing installs, does not modify any existing slugs.  
slugs are currently re-computed on every save, so an existing child will get unicode chars included in slug on next edit (even if you don't change the name).  
If already broken, admin can still edit name.