### PR TITLE
Feedings

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -48,10 +48,10 @@ def set_initial_values(kwargs, form_type):
         last_feeding = models.Feeding.objects.filter(
             child=kwargs['initial']['child']).order_by('end').last()
         if last_feeding:
-            last_type = last_feeding.type
+            last_method = last_feeding.method
             last_feed_args = {'type': last_feeding.type}
-            if last_type in ['formula', 'fortified breast milk']:
-                last_feed_args['method'] = 'bottle'
+            if last_method not in ['left breast', 'right breast']:
+                last_feed_args['method'] = last_method
             kwargs['initial'].update(last_feed_args)
 
     # Remove custom kwargs so they do not interfere with `super` calls.

--- a/core/templates/core/feeding_form.html
+++ b/core/templates/core/feeding_form.html
@@ -32,7 +32,6 @@
 {% block javascript %}
     <script type="text/javascript">
         BabyBuddy.DatetimePicker.init($('#datetimepicker_start'), {
-            defaultDate: false,
             format: '{% datetimepicker_format %}'
         });
         BabyBuddy.DatetimePicker.init($('#datetimepicker_end'), {


### PR DESCRIPTION
Closes #192.

Feel free to leave off  90e0921. I had just noticed, and agreed with, the second request:

>Similarly, feeding type (bottle, milk, ect) could be auto-populated from the previous entry, as this is usually consistent

Also, please double check for any potential issues with statistics in `dashboard/templatetags/cards.py` if `duration` == 0.