### PR TITLE
Consider last-feeding-method as empty if never-changing

### DIFF
--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -159,7 +159,8 @@ def card_feeding_last_method(context, child):
     instances = models.Feeding.objects.filter(child=child) \
         .filter(**_filter_data_age(context)) \
         .order_by('-end')[:3]
-    empty = len(instances) == 0
+    num_unique_methods = len({i.method for i in instances})
+    empty = num_unique_methods <= 1
 
     # Results are reversed for carousel forward/back behavior.
     return {


### PR DESCRIPTION
If the feeding method is always the same, the last-feeding-method card
is unhelpful. Consider it "empty" so it can be hidden by user setting.

This is an alternative solution to #139.