### PR TITLE
Convert envir variables that are supposed to be boolean to boolean

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -22,7 +22,7 @@ load_dotenv(find_dotenv())
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
 SECRET_KEY = os.environ.get('SECRET_KEY') or None
-DEBUG = os.environ.get('DEBUG') or False
+DEBUG = bool(strtobool(os.environ.get('DEBUG') or 'False'))
 
 
 # Applications
@@ -195,7 +195,7 @@ USE_L10N = True
 # conditionals on this setting. See babybuddy/forms/en/formats.py for an example
 # implementation for the English locale.
 
-USE_24_HOUR_TIME_FORMAT = strtobool(os.environ.get('USE_24_HOUR_TIME_FORMAT') or 'False')
+USE_24_HOUR_TIME_FORMAT = bool(strtobool(os.environ.get('USE_24_HOUR_TIME_FORMAT') or 'False'))
 
 
 # Static files (CSS, JavaScript, Images)
@@ -323,5 +323,5 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 BABY_BUDDY = {
     'NAP_START_MIN': os.environ.get('NAP_START_MIN') or '06:00',
     'NAP_START_MAX': os.environ.get('NAP_START_MAX') or '18:00',
-    'ALLOW_UPLOADS': os.environ.get('ALLOW_UPLOADS') or True
+    'ALLOW_UPLOADS': bool(strtobool(os.environ.get('ALLOW_UPLOADS') or 'True'))
 }

--- a/babybuddy/settings/heroku.py
+++ b/babybuddy/settings/heroku.py
@@ -5,7 +5,7 @@ from .base import *
 # Default to not allow uploads.
 # Heroku does not support file storage for this functionality.
 
-BABY_BUDDY['ALLOW_UPLOADS'] = os.environ.get('ALLOW_UPLOADS') or False
+BABY_BUDDY['ALLOW_UPLOADS'] = bool(strtobool(os.environ.get('ALLOW_UPLOADS') or 'False'))
 
 
 # Database


### PR DESCRIPTION
dotenv does not take allow for boolean environment variables and thus they have to be converted before
This should fix #354 