### PR TITLE
Fix ordering of start/stop items when start and stop times are the same

### DIFF
--- a/core/templates/timeline/_timeline.html
+++ b/core/templates/timeline/_timeline.html
@@ -17,48 +17,52 @@
 </h3>
 {% if timeline_objects %}
     <ul class="timeline m-auto">
-        {% for object in timeline_objects %}
-            <li{% cycle "" ' class="timeline-inverted"' %}>
-                <div class="timeline-badge {% if object.type == "start" %}bg-success{% elif object.type == "end" %}bg-danger{% else %}bg-info{% endif %}">
-                    <i class="icon-{{ object.model_name }}"></i>
-                </div>
-                <div class="card text-right">
-                    <div class="card-body">
-                        {{ object.event }}
-                        {% for detail in object.details %}
-                            <div><small>{{ detail }}</small></div>
-                        {% endfor %}
+        {% regroup timeline_objects by time as timeline_moments %}
+        
+        {% for moment_objects in timeline_moments %}
+            {% for object in moment_objects.list|dictsort:"type" %}
+                <li{% cycle "" ' class="timeline-inverted"' %}>
+                    <div class="timeline-badge {% if object.type == "start" %}bg-success{% elif object.type == "end" %}bg-danger{% else %}bg-info{% endif %}">
+                        <i class="icon-{{ object.model_name }}"></i>
                     </div>
-                    <div class="card-footer text-muted">
-                        {% blocktrans trimmed with since=object.time|timesince time=object.time|time %}
-                            {{ since }} ago ({{ time }})
-                        {% endblocktrans %}
-                        {% if object.duration %}
-                            <div>
-                                <small>
-                                    {% blocktrans trimmed with duration=object.duration %}
-                                        Duration: {{ duration }}
-                                    {% endblocktrans %}
-                                </small>
-                            </div>
-                        {% endif %}
-                        {% if object.time_since_prev %}
-                            <div>
-                                <small>
-                                    {% blocktrans trimmed with since=object.time_since_prev %}
-                                        {{ since }} since previous
-                                    {% endblocktrans %}
-                                </small>
-                            </div>
-                        {% endif %}
-                        {% if object.edit_link %}
-                            <div>
-                                <small><a href="{{ object.edit_link }}">{% trans "Edit" %}</a></small>
-                            </div>
-                        {% endif %}
+                    <div class="card text-right">
+                        <div class="card-body">
+                            {{ object.event }}
+                            {% for detail in object.details %}
+                                <div><small>{{ detail }}</small></div>
+                            {% endfor %}
+                        </div>
+                        <div class="card-footer text-muted">
+                            {% blocktrans trimmed with since=object.time|timesince time=object.time|time %}
+                                {{ since }} ago ({{ time }})
+                            {% endblocktrans %}
+                            {% if object.duration %}
+                                <div>
+                                    <small>
+                                        {% blocktrans trimmed with duration=object.duration %}
+                                            Duration: {{ duration }}
+                                        {% endblocktrans %}
+                                    </small>
+                                </div>
+                            {% endif %}
+                            {% if object.time_since_prev %}
+                                <div>
+                                    <small>
+                                        {% blocktrans trimmed with since=object.time_since_prev %}
+                                            {{ since }} since previous
+                                        {% endblocktrans %}
+                                    </small>
+                                </div>
+                            {% endif %}
+                            {% if object.edit_link %}
+                                <div>
+                                    <small><a href="{{ object.edit_link }}">{% trans "Edit" %}</a></small>
+                                </div>
+                            {% endif %}
+                        </div>
                     </div>
-                </div>
-            </li>
+                </li>
+            {% endfor %}
         {% endfor %}
     </ul>
     <h3 class="text-center">

--- a/core/templates/timeline/_timeline.html
+++ b/core/templates/timeline/_timeline.html
@@ -17,52 +17,48 @@
 </h3>
 {% if timeline_objects %}
     <ul class="timeline m-auto">
-        {% regroup timeline_objects by time as timeline_moments %}
-        
-        {% for moment_objects in timeline_moments %}
-            {% for object in moment_objects.list|dictsort:"type" %}
-                <li{% cycle "" ' class="timeline-inverted"' %}>
-                    <div class="timeline-badge {% if object.type == "start" %}bg-success{% elif object.type == "end" %}bg-danger{% else %}bg-info{% endif %}">
-                        <i class="icon-{{ object.model_name }}"></i>
+        {% for object in timeline_objects %}
+            <li{% cycle "" ' class="timeline-inverted"' %}>
+                <div class="timeline-badge {% if object.type == "start" %}bg-success{% elif object.type == "end" %}bg-danger{% else %}bg-info{% endif %}">
+                    <i class="icon-{{ object.model_name }}"></i>
+                </div>
+                <div class="card text-right">
+                    <div class="card-body">
+                        {{ object.event }}
+                        {% for detail in object.details %}
+                            <div><small>{{ detail }}</small></div>
+                        {% endfor %}
                     </div>
-                    <div class="card text-right">
-                        <div class="card-body">
-                            {{ object.event }}
-                            {% for detail in object.details %}
-                                <div><small>{{ detail }}</small></div>
-                            {% endfor %}
-                        </div>
-                        <div class="card-footer text-muted">
-                            {% blocktrans trimmed with since=object.time|timesince time=object.time|time %}
-                                {{ since }} ago ({{ time }})
-                            {% endblocktrans %}
-                            {% if object.duration %}
-                                <div>
-                                    <small>
-                                        {% blocktrans trimmed with duration=object.duration %}
-                                            Duration: {{ duration }}
-                                        {% endblocktrans %}
-                                    </small>
-                                </div>
-                            {% endif %}
-                            {% if object.time_since_prev %}
-                                <div>
-                                    <small>
-                                        {% blocktrans trimmed with since=object.time_since_prev %}
-                                            {{ since }} since previous
-                                        {% endblocktrans %}
-                                    </small>
-                                </div>
-                            {% endif %}
-                            {% if object.edit_link %}
-                                <div>
-                                    <small><a href="{{ object.edit_link }}">{% trans "Edit" %}</a></small>
-                                </div>
-                            {% endif %}
-                        </div>
+                    <div class="card-footer text-muted">
+                        {% blocktrans trimmed with since=object.time|timesince time=object.time|time %}
+                            {{ since }} ago ({{ time }})
+                        {% endblocktrans %}
+                        {% if object.duration %}
+                            <div>
+                                <small>
+                                    {% blocktrans trimmed with duration=object.duration %}
+                                        Duration: {{ duration }}
+                                    {% endblocktrans %}
+                                </small>
+                            </div>
+                        {% endif %}
+                        {% if object.time_since_prev %}
+                            <div>
+                                <small>
+                                    {% blocktrans trimmed with since=object.time_since_prev %}
+                                        {{ since }} since previous
+                                    {% endblocktrans %}
+                                </small>
+                            </div>
+                        {% endif %}
+                        {% if object.edit_link %}
+                            <div>
+                                <small><a href="{{ object.edit_link }}">{% trans "Edit" %}</a></small>
+                            </div>
+                        {% endif %}
                     </div>
-                </li>
-            {% endfor %}
+                </div>
+            </li>
         {% endfor %}
     </ul>
     <h3 class="text-center">

--- a/core/timeline.py
+++ b/core/timeline.py
@@ -26,7 +26,10 @@ def get_objects(date, child=None):
 
     explicit_type_ordering = {'start': 0, 'end': 1}
     events.sort(
-        key=lambda x: (x['time'], explicit_type_ordering.get(x.get('type'), -1)), 
+        key=lambda x: (
+            x['time'],
+            explicit_type_ordering.get(x.get('type'), -1),
+        ),
         reverse=True,
     )
 

--- a/core/timeline.py
+++ b/core/timeline.py
@@ -24,7 +24,11 @@ def get_objects(date, child=None):
     _add_tummy_times(min_date, max_date, events, child)
     _add_notes(min_date, max_date, events, child)
 
-    events.sort(key=lambda x: x['time'], reverse=True)
+    explicit_type_ordering = {'start': 0, 'end': 1}
+    events.sort(
+        key=lambda x: (x['time'], explicit_type_ordering.get(x.get('type'), -1)), 
+        reverse=True,
+    )
 
     return events
 


### PR DESCRIPTION
# Problem

It can be handy sometimes to retroactively add, for example, a "feeding" quickly from the menu without editing the start and end times explicitly. We make use of this feature a lot right when we are done with a feeding but forgot to start a timer for measuring the time it took to do the feeding. This makes it so that start and end times are stored as the same timepoint.

However, when viewing timeline items for these entries, they are ordered the "wrong way" (better said "illogical"), listing "start" after "end":

![grafik](https://user-images.githubusercontent.com/542105/149093925-ba5f140a-6cfa-45c8-a7ed-4b89e662a775.png)

_Small nuisance my partner was mentioning, and which was relatively easy to fix now that I am more used to the codebase :-)_

# Solution

Use lexical ordering of `timeline_entry.type` in the template to force the order of entries at equal timepoints:

![grafik](https://user-images.githubusercontent.com/542105/149114173-655b60c4-19f0-4c76-b56c-d74022820a21.png)