### PR TITLE
Rearrange dashboard cards to set timer card first

### DIFF
--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -11,12 +11,12 @@
 
 {% block content %}
     <div id="dashboard-child" class="card-columns">
+        {% card_timer_list object %}
         {% card_feeding_last object %}
         {% card_diaperchange_last object %}
         {% card_sleep_last object %}
         {% card_feeding_last_method object %}
         {% card_feeding_day object %}
-        {% card_timer_list object %}
         {% card_statistics object %}
         {% card_sleep_day object %}
         {% card_sleep_naps_day object %}


### PR DESCRIPTION
Having the timer card show up first is super helpful, especially when you have "Hide Empty Dashboard Cards" set