### PR TITLE
breakout feeding types

### DIFF
--- a/reports/graphs/feeding_amounts.py
+++ b/reports/graphs/feeding_amounts.py
@@ -7,30 +7,63 @@ import plotly.graph_objs as go
 
 from reports import utils
 
-
 def feeding_amounts(instances):
     """
     Create a graph showing daily feeding amounts over time.
     :param instances: a QuerySet of Feeding instances.
     :returns: a tuple of the the graph's html and javascript.
     """
-    totals = {}
+    feeding_types=[
+            'breast milk',
+            'formula',
+            'fortified breast milk',
+            'solid food',
+        ]
+    feeding_types_desc=[
+            'Breast milk',
+            'Formula',
+            'Fortified breast milk',
+            'Solid food',
+        ]
+    total_idx=len(feeding_types)+1 #+1 for aggregate total
+    totals_list=list()
+    for i in range(total_idx):
+        totals_list.append({})
     for instance in instances:
         end = timezone.localtime(instance.end)
         date = end.date()
-        if date not in totals.keys():
-            totals[date] = 0
-        totals[date] += instance.amount or 0
+        if date not in totals_list[total_idx-1].keys():
+            for item in totals_list:
+                item[date]=0
+        feeding_idx=feeding_types.index(instance.type)
+        totals_list[feeding_idx][date]+= instance.amount or 0
+        totals_list[total_idx-1][date]+= instance.amount or 0
+    zeros = [0 for a in totals_list[total_idx-1].values()]
+    
+    #sum each feeding type for graph
+    amounts_array=[]
+    for i in range(total_idx):
+        amounts_array.append([round(amount, 2) for amount in totals_list[i].values()])
+    
+    traces=[]
+    for i in range(total_idx-1):
+        traces.append(go.Bar(
+            name=feeding_types_desc[i],
+            x=list(totals_list[total_idx-1].keys()),
+            y=amounts_array[i],
+            text=amounts_array[i]
 
-    amounts = [round(amount, 2) for amount in totals.values()]
-    trace = go.Bar(
-        name=_('Total feeding amount'),
-        x=list(totals.keys()),
-        y=amounts,
+        ))
+
+    traces.append(go.Bar(
+        name=_('Total'),
+        x=list(totals_list[total_idx-1].keys()),
+        y=zeros,
         hoverinfo='text',
         textposition='outside',
-        text=amounts
-    )
+        text=amounts_array[total_idx-1]
+    ))
+
 
     layout_args = utils.default_graph_layout_options()
     layout_args['title'] = _('<b>Total Feeding Amounts</b>')
@@ -39,8 +72,9 @@ def feeding_amounts(instances):
     layout_args['yaxis']['title'] = _('Feeding amount')
 
     fig = go.Figure({
-        'data': [trace],
+        'data': traces,
         'layout': go.Layout(**layout_args)
     })
+    fig.update_layout(barmode='stack')
     output = plotly.plot(fig, output_type='div', include_plotlyjs=False)
     return utils.split_graph_output(output)

--- a/reports/graphs/feeding_amounts.py
+++ b/reports/graphs/feeding_amounts.py
@@ -62,7 +62,8 @@ def feeding_amounts(instances):
         y=zeros,
         hoverinfo='text',
         textposition='outside',
-        text=amounts_array[total_idx-1]
+        text=amounts_array[total_idx-1],
+        showlegend=False
     ))
 
     layout_args = utils.default_graph_layout_options()
@@ -76,7 +77,5 @@ def feeding_amounts(instances):
         'layout': go.Layout(**layout_args)
     })
     fig.update_layout(barmode='stack')
-    fig.update_yaxes(automargin=True)
-    fig.update_xaxes(automargin=True)
     output = plotly.plot(fig, output_type='div', include_plotlyjs=False)
     return utils.split_graph_output(output)

--- a/reports/graphs/feeding_amounts.py
+++ b/reports/graphs/feeding_amounts.py
@@ -7,26 +7,27 @@ import plotly.graph_objs as go
 
 from reports import utils
 
+
 def feeding_amounts(instances):
     """
     Create a graph showing daily feeding amounts over time.
     :param instances: a QuerySet of Feeding instances.
     :returns: a tuple of the the graph's html and javascript.
     """
-    feeding_types=[
+    feeding_types = [
             'breast milk',
             'formula',
             'fortified breast milk',
             'solid food',
         ]
-    feeding_types_desc=[
+    feeding_types_desc = [
             'Breast milk',
             'Formula',
             'Fortified breast milk',
             'Solid food',
         ]
-    total_idx=len(feeding_types)+1 #+1 for aggregate total
-    totals_list=list()
+    total_idx = len(feeding_types) + 1  # +1 for aggregate total
+    totals_list = list()
     for i in range(total_idx):
         totals_list.append({})
     for instance in instances:
@@ -34,18 +35,18 @@ def feeding_amounts(instances):
         date = end.date()
         if date not in totals_list[total_idx-1].keys():
             for item in totals_list:
-                item[date]=0
-        feeding_idx=feeding_types.index(instance.type)
-        totals_list[feeding_idx][date]+= instance.amount or 0
-        totals_list[total_idx-1][date]+= instance.amount or 0
+                item[date] = 0
+        feeding_idx = feeding_types.index(instance.type)
+        totals_list[feeding_idx][date] += instance.amount or 0
+        totals_list[total_idx-1][date] += instance.amount or 0
     zeros = [0 for a in totals_list[total_idx-1].values()]
-    
-    #sum each feeding type for graph
-    amounts_array=[]
+
+    # sum each feeding type for graph
+    amounts_array = []
     for i in range(total_idx):
-        amounts_array.append([round(amount, 2) for amount in totals_list[i].values()])
-    
-    traces=[]
+        amounts_array.append([round(a, 2) for a in totals_list[i].values()])
+
+    traces = []
     for i in range(total_idx-1):
         traces.append(go.Bar(
             name=feeding_types_desc[i],
@@ -64,7 +65,6 @@ def feeding_amounts(instances):
         text=amounts_array[total_idx-1]
     ))
 
-
     layout_args = utils.default_graph_layout_options()
     layout_args['title'] = _('<b>Total Feeding Amounts</b>')
     layout_args['xaxis']['title'] = _('Date')
@@ -76,5 +76,7 @@ def feeding_amounts(instances):
         'layout': go.Layout(**layout_args)
     })
     fig.update_layout(barmode='stack')
+    fig.update_yaxes(automargin=True)
+    fig.update_xaxes(automargin=True)
     output = plotly.plot(fig, output_type='div', include_plotlyjs=False)
     return utils.split_graph_output(output)


### PR DESCRIPTION
There are some bugs that this change appears to create.
* on mobile it puts the legend over the graph
* on mobile it makes the trend very narrow 

I tried adding this code to the layout but on mobile it overlaps the x axis labels
        `'legend':{
            'orientation':'h'
        }`

It might be better to just not have a label. 
in reference to #383  