### PR TITLE
change api date filter to datetime filter

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from django_filters import rest_framework as filters
-
 from core import models
+from django_filters import rest_framework as filters
 
 
 class CharInFilter(filters.BaseInFilter, filters.CharFilter):
@@ -26,12 +25,12 @@ class TagsFieldFilter(filters.FilterSet):
 
 
 class TimeFieldFilter(ChildFieldFilter):
-    date = filters.DateFilter(field_name="time__date", label="Date")
-    date_max = filters.DateFilter(
-        field_name="time__date", label="Max. Date", lookup_expr="lte"
+    date = filters.IsoDateTimeFilter(field_name="time", label="DateTime")
+    date_max = filters.IsoDateTimeFilter(
+        field_name="time", label="Max. DateTime", lookup_expr="lte"
     )
-    date_min = filters.DateFilter(
-        field_name="time__date", label="Min. Date", lookup_expr="gte"
+    date_min = filters.IsoDateTimeFilter(
+        field_name="time", label="Min. DateTime", lookup_expr="gte"
     )
 
     class Meta:
@@ -40,19 +39,19 @@ class TimeFieldFilter(ChildFieldFilter):
 
 
 class StartEndFieldFilter(ChildFieldFilter):
-    end = filters.DateFilter(field_name="end__date", label="End Date")
-    end_max = filters.DateFilter(
-        field_name="end__date", label="Max. End Date", lookup_expr="lte"
+    end = filters.IsoDateTimeFilter(field_name="end", label="End DateTime")
+    end_max = filters.IsoDateTimeFilter(
+        field_name="end", label="Max. End DateTime", lookup_expr="lte"
     )
-    end_min = filters.DateFilter(
-        field_name="end__date", label="Min. End Date", lookup_expr="gte"
+    end_min = filters.IsoDateTimeFilter(
+        field_name="end", label="Min. End DateTime", lookup_expr="gte"
     )
-    start = filters.DateFilter(field_name="start__date", label="Start Date")
-    start_max = filters.DateFilter(
-        field_name="start__date", lookup_expr="lte", label="Max. End Date"
+    start = filters.IsoDateTimeFilter(field_name="start", label="Start DateTime")
+    start_max = filters.IsoDateTimeFilter(
+        field_name="start", lookup_expr="lte", label="Max. End DateTime"
     )
-    start_min = filters.DateFilter(
-        field_name="start__date", lookup_expr="gte", label="Min. Start Date"
+    start_min = filters.IsoDateTimeFilter(
+        field_name="start", lookup_expr="gte", label="Min. Start DateTime"
     )
 
     class Meta:

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
-from django.urls import reverse
-from django.utils import timezone
-
-from rest_framework import status
-from rest_framework.test import APITestCase
-
 from babybuddy.models import User
 from core import models
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
 
 
 class TestBase:
@@ -257,6 +255,19 @@ class FeedingAPITestCase(TestBase.BabyBuddyAPITestCaseBase):
                 "tags": [],
             },
         )
+
+    # check backwards compatibility
+    def test_get_with_date_filter(self):
+        response = self.client.get(self.endpoint, {"start_min": "2017-11-18"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+
+    def test_get_with_iso_filter(self):
+        response = self.client.get(
+            self.endpoint, {"start_min": "2017-11-18T11:30:00-05:00"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
 
     def test_post(self):
         data = {

--- a/openapi-schema.yml
+++ b/openapi-schema.yml
@@ -329,19 +329,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       - name: solid
@@ -444,7 +444,7 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
@@ -456,7 +456,7 @@ paths:
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       - name: solid
@@ -516,7 +516,7 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
@@ -528,7 +528,7 @@ paths:
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       - name: solid
@@ -605,13 +605,13 @@ paths:
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       - name: solid
@@ -688,13 +688,13 @@ paths:
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       - name: solid
@@ -746,13 +746,13 @@ paths:
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: method
@@ -771,19 +771,19 @@ paths:
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: type
@@ -868,19 +868,19 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: method
@@ -899,19 +899,19 @@ paths:
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: type
@@ -953,19 +953,19 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: method
@@ -984,19 +984,19 @@ paths:
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: type
@@ -1049,19 +1049,19 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: method
@@ -1080,19 +1080,19 @@ paths:
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: type
@@ -1145,19 +1145,19 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: method
@@ -1176,19 +1176,19 @@ paths:
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: type
@@ -1233,19 +1233,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       responses:
@@ -1319,19 +1319,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       responses:
@@ -1362,19 +1362,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       requestBody:
@@ -1416,19 +1416,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       requestBody:
@@ -1470,19 +1470,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       responses:
@@ -1516,37 +1516,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       responses:
@@ -1620,37 +1620,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       responses:
@@ -1681,37 +1681,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       requestBody:
@@ -1753,37 +1753,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       requestBody:
@@ -1825,37 +1825,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       responses:
@@ -1889,19 +1889,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       responses:
@@ -1975,19 +1975,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       responses:
@@ -2018,19 +2018,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       requestBody:
@@ -2072,19 +2072,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       requestBody:
@@ -2126,19 +2126,19 @@ paths:
       - name: date
         required: false
         in: query
-        description: Date
+        description: DateTime
         schema:
           type: string
       - name: date_max
         required: false
         in: query
-        description: Max. Date
+        description: Max. DateTime
         schema:
           type: string
       - name: date_min
         required: false
         in: query
-        description: Min. Date
+        description: Min. DateTime
         schema:
           type: string
       responses:
@@ -2178,37 +2178,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: user
@@ -2294,37 +2294,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: user
@@ -2367,37 +2367,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: user
@@ -2451,37 +2451,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: user
@@ -2535,37 +2535,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       - name: user
@@ -2605,37 +2605,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       responses:
@@ -2709,37 +2709,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       responses:
@@ -2770,37 +2770,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       requestBody:
@@ -2842,37 +2842,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       requestBody:
@@ -2914,37 +2914,37 @@ paths:
       - name: end
         required: false
         in: query
-        description: End Date
+        description: End DateTime
         schema:
           type: string
       - name: end_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: end_min
         required: false
         in: query
-        description: Min. End Date
+        description: Min. End DateTime
         schema:
           type: string
       - name: start
         required: false
         in: query
-        description: Start Date
+        description: Start DateTime
         schema:
           type: string
       - name: start_max
         required: false
         in: query
-        description: Max. End Date
+        description: Max. End DateTime
         schema:
           type: string
       - name: start_min
         required: false
         in: query
-        description: Min. Start Date
+        description: Min. Start DateTime
         schema:
           type: string
       responses:


### PR DESCRIPTION
Change API DateFilter to IsoDateTimeFilter to allow for more precise filtering at API level.

Will allow downstream apps to do things such as https://github.com/jcgoette/baby_buddy_homeassistant/issues/58.

I haven't contributed in a while, so please check me closely. :)