### PR TITLE
Allow end of feeding to be in the future

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -361,7 +361,6 @@ class Feeding(models.Model):
 
     def clean(self):
         validate_time(self.start, "start")
-        validate_time(self.end, "end")
         validate_duration(self)
         validate_unique_period(Feeding.objects.filter(child=self.child), self)
 


### PR DESCRIPTION
This makes totally sense for us as we sometimes want to create the feeding entry in babybuddy while the feeding is still ongoing but we already know that we are going to end the feeding some short time in the future (like a few minutes).

