### PR TITLE
Fix KeyError at /children/x/reports/sleep/pattern/

### DIFF
--- a/reports/graphs/sleep_pattern.py
+++ b/reports/graphs/sleep_pattern.py
@@ -190,6 +190,8 @@ def _add_adjustment(adjustment, days):
     :param blocks: List of days
     """
     column = adjustment.pop("column")
+    if not column in days:
+        days[column] = []
     # Fake (0) entry to keep the color switching logic working.
     days[column].append({"time": 0, "label": 0})
 


### PR DESCRIPTION
Fixes

```
  File "/app/babybuddy/reports/views.py", line 141, in get_context_data
    context["html"], context["js"] = graphs.sleep_pattern(instances)
  File "/app/babybuddy/reports/graphs/sleep_pattern.py", line 97, in sleep_pattern
    _add_adjustment(adjustment, days)
  File "/app/babybuddy/reports/graphs/sleep_pattern.py", line 194, in _add_adjustment
    days[column].append({"time": 0, "label": 0})

Exception Type: KeyError at /children/x/reports/sleep/pattern/
Exception Value: '2022-04-18'
```

which occurred with sleeping entry having start=`2022-04-17 20:58` and end=`2022-04-18 00:10`.

