### PR TITLE
Use bash script for Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bash Profile.sh
+web: bash Procfile.sh

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-release: python manage.py migrate
-web: gunicorn babybuddy.wsgi:application --timeout 30 --log-file -
+web: bash Profile.sh

--- a/Procfile.sh
+++ b/Procfile.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+python manage.py migrate
+python manage.py createcachetable
+
+gunicorn babybuddy.wsgi:application --timeout 30 --log-file -

--- a/app.json
+++ b/app.json
@@ -35,11 +35,8 @@
     "environments": {
         "review": {
           "scripts": {
-            "postdeploy": "python manage.py migrate && python manage.py createcachetable && python manage.py reset --no-input"
+            "postdeploy": "python manage.py reset --no-input"
           }
         }
-      },
-    "scripts": {
-        "postdeploy": "python manage.py migrate && python manage.py createcachetable"
-    }
+      }
 }


### PR DESCRIPTION
This allows for more flexibility without requiring Heroku's post deploy and release hooks that are not supported in all environments.