### PR TITLE
✨ adds support for other S3-like providers

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -227,6 +227,8 @@ AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID") or None
 
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY") or None
 
+AWS_S3_ENDPOINT_URL = os.environ.get("AWS_S3_ENDPOINT_URL") or None
+
 if AWS_STORAGE_BUCKET_NAME:
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -57,6 +57,13 @@ If you would like to use AWS S3 for storage on ephemeral storage platforms like
 Heroku you will need to create a bucket and add its name. See django-storages'
 [Amazon S3 documentation](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html).
 
+## `AWS_S3_ENDPOINT_URL`
+
+*Default:* `None`
+
+Custom URL to use when connecting to S3, including scheme.
+This allows to use a S3-compatible storage service of another provider than AWS.
+
 ## `CSRF_TRUSTED_ORIGINS`
 
 *Default:* `None`


### PR DESCRIPTION
Apart from AWS, there many cloud providers that provides S3-compatible object storage. To use on of these providers, an `AWS_S3_ENDPOINT_URL` variable must be specified. I propose to add support for this variable in `base.py` setting file