### PR TITLE
Fix filtering not working for capitalized tags

### DIFF
--- a/babybuddy/management/commands/fake.py
+++ b/babybuddy/management/commands/fake.py
@@ -44,9 +44,10 @@ class Command(BaseCommand):
         children = int(kwargs["children"]) or 1
         days = int(kwargs["days"]) or 31
 
-        for word in self.faker.words(10, unique=True):
+        for i in range(0, 10):
+            text = self.faker.password(randint(4, 10))
             try:
-                tag = models.Tag.objects.create(name=word)
+                tag = models.Tag.objects.create(name=text)
                 tag.save()
                 self.tags.append(tag)
             except IntegrityError:

--- a/core/filters.py
+++ b/core/filters.py
@@ -9,8 +9,7 @@ from core import models
 class TagFilter(django_filters.FilterSet):
     tag = django_filters.ModelChoiceFilter(
         label=_("Tag"),
-        field_name="tags__slug",
-        to_field_name="slug",
+        field_name="tags__name",
         distinct=True,
         queryset=models.Tag.objects.all().order_by("name"),
     )


### PR DESCRIPTION
Now the filter uses exclusively the name field.

Closes #467.