### PR TITLE
Fix dayssince sometimes being off by 1 day depending on timezone

### DIFF
--- a/core/templatetags/duration.py
+++ b/core/templatetags/duration.py
@@ -103,7 +103,7 @@ def dayssince(value, today=None):
     :returns: the formatted string
     """
     if today is None:
-        today = timezone.datetime.now().date()
+        today = timezone.localtime().date()
 
     delta = today - value
 


### PR DESCRIPTION
dayssince pulled UTC date for now() instead of using localtime(). This would sometimes cause all the days to be one off (e.g. "today" -> "yesterday").

