### PR TITLE
🚸 adds a child quick switch in breadcrumb

### DIFF
--- a/core/templates/core/child_detail.html
+++ b/core/templates/core/child_detail.html
@@ -1,11 +1,13 @@
 {% extends 'babybuddy/page.html' %}
-{% load duration i18n imagekit static %}
+{% load breadcrumb duration i18n imagekit static %}
 
 {% block title %}{{ object }}{% endblock %}
 
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a href="{% url 'core:child-list' %}">{% trans "Children" %}</a></li>
-    <li class="breadcrumb-item font-weight-bold">{{ object }}</li>
+    <li class="breadcrumb-item font-weight-bold">
+        {% child_quick_switch object 'core:child' %}
+    </li>
 {% endblock %}
 
 {% block content %}

--- a/core/templates/core/child_quick_switch.html
+++ b/core/templates/core/child_quick_switch.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+<a href="{% url 'core:child' current_child.slug %}">{{ current_child }}</a>
+{% if children.count > 0 %}
+    <a href="#" class="ml-1 pl-1 pr-1 btn btn-xs btn-outline-light dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">{% trans 'Switch child' %}</span>
+    </a>
+    <div class="dropdown-menu dropdown-menu-right">
+        <h6 class="dropdown-header">{% trans "Switch to…" %}</h6>
+        {% for child in children %}
+            <a class="dropdown-item d-flex align-items-center" href="{% url target_url child.slug %}">
+                {% include "core/child_thumbnail.html" %}
+                <span class="text-wrap ml-2">{{ child }}</span>
+            </a>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/core/templates/core/child_quick_switch.html
+++ b/core/templates/core/child_quick_switch.html
@@ -2,8 +2,12 @@
 
 <a href="{% url 'core:child' current_child.slug %}">{{ current_child }}</a>
 {% if children.count > 0 %}
-    <a href="#" class="ml-1 pl-1 pr-1 btn btn-xs btn-outline-light dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <a href="#" class="ml-1 pl-1 pr-1 dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="sr-only">{% trans 'Switch child' %}</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"             fill="currentColor" viewBox="0 0 16 16">
+            <path d="M3.626 6.832A.5.5 0 0 1 4 6h8a.5.5 0 0 1 .374.832l-4 4.5a.5.5 0 0 1-.748 0l-4-4.5z"></path>
+            <path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm15 0a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2z"></path>
+        </svg>
     </a>
     <div class="dropdown-menu dropdown-menu-right">
         <h6 class="dropdown-header">{% trans "Switch to…" %}</h6>

--- a/core/templatetags/breadcrumb.py
+++ b/core/templatetags/breadcrumb.py
@@ -1,0 +1,16 @@
+from django import template
+
+from core.models import Child
+
+register = template.Library()
+
+
+@register.inclusion_tag("core/child_quick_switch.html")
+def child_quick_switch(current_child, target_url):
+    children = Child.objects.exclude(slug=current_child.slug)
+
+    return {
+        "children": children,
+        "current_child": current_child,
+        "target_url": target_url,
+    }

--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -1,11 +1,13 @@
 {% extends 'babybuddy/page.html' %}
-{% load cards i18n %}
+{% load breadcrumb cards i18n %}
 
 {% block title %}{% trans "Dashboard" %} - {{ object }}{% endblock %}
 
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a href="{% url 'core:child-list' %}">{% trans "Children" %}</a></li>
-    <li class="breadcrumb-item font-weight-bold"><a href="{% url 'core:child' object.slug %}">{{ object }}</a></li>
+    <li class="breadcrumb-item font-weight-bold">
+        {% child_quick_switch object 'dashboard:dashboard-child' %}
+    </li>
     <li class="breadcrumb-item active" aria-current="page">{% trans "Dashboard" %}</li>
 {% endblock %}
 

--- a/reports/templates/reports/base.html
+++ b/reports/templates/reports/base.html
@@ -5,6 +5,4 @@
 
 {% block breadcrumbs %}
     <li class="breadcrumb-item"><a href="{% url 'core:child-list' %}">{% trans "Children" %}</a></li>
-    <li class="breadcrumb-item font-weight-bold"><a href="{% url 'core:child' object.slug %}">{{ object }}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'reports:report-list' object.slug %}">{% trans "Reports" %}</a></li>
 {% endblock %}

--- a/reports/templates/reports/bmi_change.html
+++ b/reports/templates/reports/bmi_change.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-bmi-change-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "BMI" %}</li>
 {% endblock %}

--- a/reports/templates/reports/breadcrumb_common_chunk.html
+++ b/reports/templates/reports/breadcrumb_common_chunk.html
@@ -1,0 +1,7 @@
+{% load breadcrumb i18n %}
+
+<li class="breadcrumb-item font-weight-bold">
+    {% child_quick_switch object target_url %}
+</li>
+<li class="breadcrumb-item"><a href="{% url 'reports:report-list' object.slug %}">{% trans "Reports" %}</a></li>
+

--- a/reports/templates/reports/diaperchange_amounts.html
+++ b/reports/templates/reports/diaperchange_amounts.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-diaperchange-amounts-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Diaper Amounts" %}</li>
 {% endblock %}

--- a/reports/templates/reports/diaperchange_lifetimes.html
+++ b/reports/templates/reports/diaperchange_lifetimes.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-diaperchange-lifetimes-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Diaper Lifetimes" %}</li>
 {% endblock %}

--- a/reports/templates/reports/diaperchange_types.html
+++ b/reports/templates/reports/diaperchange_types.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-diaperchange-types-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Diaper Change Types" %}</li>
 {% endblock %}

--- a/reports/templates/reports/feeding_amounts.html
+++ b/reports/templates/reports/feeding_amounts.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-feeding-amounts-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Feeding Amounts" %}</li>
 {% endblock %}

--- a/reports/templates/reports/feeding_duration.html
+++ b/reports/templates/reports/feeding_duration.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-feeding-duration-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Average Feeding Durations" %}</li>
 {% endblock %}

--- a/reports/templates/reports/head_circumference_change.html
+++ b/reports/templates/reports/head_circumference_change.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-head-circumference-change-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Head Circumference" %}</li>
 {% endblock %}

--- a/reports/templates/reports/height_change.html
+++ b/reports/templates/reports/height_change.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-height-change-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Height" %}</li>
 {% endblock %}

--- a/reports/templates/reports/pumping_amounts.html
+++ b/reports/templates/reports/pumping_amounts.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-pumping-amounts-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Pumping" %}</li>
 {% endblock %}

--- a/reports/templates/reports/report_list.html
+++ b/reports/templates/reports/report_list.html
@@ -1,7 +1,16 @@
 {% extends 'reports/base.html' %}
-{% load i18n static %}
+{% load breadcrumb i18n static %}
 
 {% block title %}{% trans "Reports" %} - {{ object }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li class="breadcrumb-item font-weight-bold">
+        {% child_quick_switch object 'reports:report-list' %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{% trans "Reports" %}</li>
+
+{% endblock %}
 
 {% block content %}
     <div class="container-fluid">

--- a/reports/templates/reports/sleep_pattern.html
+++ b/reports/templates/reports/sleep_pattern.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-sleep-pattern-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Sleep Pattern" %}</li>
 {% endblock %}

--- a/reports/templates/reports/sleep_totals.html
+++ b/reports/templates/reports/sleep_totals.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-sleep-totals-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Sleep Totals" %}</li>
 {% endblock %}

--- a/reports/templates/reports/tummytime_duration.html
+++ b/reports/templates/reports/tummytime_duration.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-tummy-time-duration-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Total Tummy Time Durations" %}</li>
 {% endblock %}

--- a/reports/templates/reports/weight_change.html
+++ b/reports/templates/reports/weight_change.html
@@ -5,5 +5,6 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'reports/breadcrumb_common_chunk.html' with target_url='reports:report-weight-change-child' %}
     <li class="breadcrumb-item active" aria-current="page">{% trans "Weight" %}</li>
 {% endblock %}


### PR DESCRIPTION
I found it tedious to consult graphs for one of my twins, then to consult the same graphs for the other. So I propose a quick switch in the breadcrumb. It is available in dashboard, timeline and reports breadcrumbs and allows to quickly switch to the "same" page but for another child

[Capture d’écran vidéo de 03-08-2022 14:59:36.webm](https://user-images.githubusercontent.com/862310/182614012-1012dd83-18d5-40fe-990c-345abe6b002b.webm)

