### PR TITLE
Install GNU gettext at gitpod startup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,7 @@
 tasks:
   - init: >
+      sudo apt update &&
+      sudo apt -y install gettext &&
       pipenv install --three &&
       npm install -g gulp-cli &&
       npm install &&


### PR DESCRIPTION
It's handy to use GitPod to update translations. So I would like to have `gettext` pre-installed for GitPod sessions. Per my experience, installing `gettext` in GitPod would not take much time.