### PR TITLE
CapRover

### DIFF
--- a/Procfile.sh
+++ b/Procfile.sh
@@ -3,4 +3,4 @@
 python manage.py migrate
 python manage.py createcachetable
 
-gunicorn babybuddy.wsgi:application --timeout 30 --log-file -
+gunicorn babybuddy.wsgi:application -b 0.0.0.0:80 --timeout 30 --log-file -

--- a/captain-definition
+++ b/captain-definition
@@ -9,7 +9,7 @@
     "COPY . /app",
     "RUN pip3 install -U --no-cache-dir pip && pip install --no-cache-dir --ignore-installed -r requirements.txt",
     "RUN apk del --purge build-dependencies && rm -rf /root/.cache",
-    "EXPOSE 80",
+    "EXPOSE 8000",
     "CMD sh /app/Procfile.sh"
   ]
 }

--- a/captain-definition
+++ b/captain-definition
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "dockerfileLines": [
-    "FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.14",
+    "FROM python:3.10-alpine",
     "RUN apk add --no-cache --virtual=build-dependencies build-base curl jpeg-dev libffi-dev libxml2-dev libxslt-dev postgresql-dev python3-dev zlib-dev",
     "RUN apk add --no-cache jpeg libffi libpq libxml2 libxslt py3-mysqlclient py3-pip python3",
     "RUN mkdir -p /app",

--- a/captain-definition
+++ b/captain-definition
@@ -9,7 +9,7 @@
     "COPY . /app",
     "RUN pip3 install -U --no-cache-dir pip && pip install --no-cache-dir --ignore-installed -r requirements.txt",
     "RUN apk del --purge build-dependencies && rm -rf /root/.cache",
-    "EXPOSE 8000",
+    "EXPOSE 80",
     "CMD sh /app/Procfile.sh"
   ]
 }

--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 2,
+  "dockerfileLines": [
+    "FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.14",
+    "RUN apk add --no-cache --virtual=build-dependencies build-base curl jpeg-dev libffi-dev libxml2-dev libxslt-dev postgresql-dev python3-dev zlib-dev",
+    "RUN apk add --no-cache jpeg libffi libpq libxml2 libxslt py3-mysqlclient py3-pip python3",
+    "RUN mkdir -p /app",
+    "WORKDIR /app",
+    "COPY . /app",
+    "RUN pip3 install -U --no-cache-dir pip && pip install --no-cache-dir --ignore-installed -r requirements.txt",
+    "RUN apk del --purge build-dependencies && rm -rf /root/.cache",
+    "EXPOSE 80",
+    "CMD sh /app/Procfile.sh"
+  ]
+}


### PR DESCRIPTION
# Objective

With the [Removal of Heroku Free Product Plans](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq) announcement I am looking at self-hosted PaaS alternatives as my experiences with Render.com, Fly.io, and Railway.app were not great.

This branch is for considering [CapRover](https://caprover.com/) and is live at https://demo.ops.baby-buddy.net/.

## Positive impressions

- Very simple install of the CapRover
- Built in admin web interface
- Nice deploy experience
- Simple definition for Baby Buddy container

## Negative impressions

- No built in "cron"(see caprover/caprover/issues/38 for further research)
- Dockerfile lines somewhat dense and based on LSIO work (so would need to be kept in line)
- Had to modify `Profile.sh` to force `0.0.0.0:80` bind (though of course a separate run file could be used)
- CLI does not offer ability to run commands in container (API might? For now there is [How to run shell inside my application](https://caprover.com/docs/troubleshooting.html#how-to-run-shell-inside-my-application-inside-container))

Compare to https://github.com/babybuddy/babybuddy/pull/526