### PR TITLE
Data mismatch - Issue #520

### DIFF
--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -135,7 +135,7 @@ def card_feeding_day(context, child, end_date=None):
     # do one pass over the data and add it to the appropriate day
     for instance in instances:
         # convert to local tz and push feed_date to end so we're comparing apples to apples for the date
-        feed_date = timezone.localtime(instance.start).replace(
+        feed_date = timezone.localtime(instance.end).replace(
             hour=23, minute=59, second=59, microsecond=9999
         )
         idx = (end_date - feed_date).days


### PR DESCRIPTION
Updates cards.py to use feeding end time to calculate total food for a given day. Ensures consistency between the dashboard and reporting.

First time using Github or contributing to any project. Apologies if I'm doing this incorrectly.