### PR TITLE
Add forward auth by way of remote user

### DIFF
--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -10,10 +10,6 @@ from os import getenv
 from django.contrib.auth.middleware import RemoteUserMiddleware
 
 
-class CustomRemoteUser(RemoteUserMiddleware):
-    header = getenv("PROXY_HEADER", "HTTP_REMOTE_USER")
-
-
 def update_en_us_date_formats():
     """
     Update the datetime formats for the en-US locale. This is handled here and
@@ -149,3 +145,7 @@ class RollingSessionMiddleware:
             else:
                 request.session["session_refresh"] = int(time.time())
         return self.get_response(request)
+
+
+class CustomRemoteUser(RemoteUserMiddleware):
+    header = getenv("PROXY_HEADER", "HTTP_REMOTE_USER")

--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -1,4 +1,5 @@
-import time
+from os import getenv
+from time import time
 
 import pytz
 
@@ -6,7 +7,6 @@ from django.conf import settings
 from django.utils import timezone, translation
 from django.conf.locale.en import formats as formats_en_us
 from django.conf.locale.en_GB import formats as formats_en_gb
-from os import getenv
 from django.contrib.auth.middleware import RemoteUserMiddleware
 
 
@@ -136,16 +136,20 @@ class RollingSessionMiddleware:
             session_refresh = request.session.get("session_refresh")
             if session_refresh:
                 try:
-                    delta = int(time.time()) - session_refresh
+                    delta = int(time()) - session_refresh
                 except (ValueError, TypeError):
                     delta = settings.ROLLING_SESSION_REFRESH + 1
                 if delta > settings.ROLLING_SESSION_REFRESH:
-                    request.session["session_refresh"] = int(time.time())
+                    request.session["session_refresh"] = int(time())
                     request.session.set_expiry(settings.SESSION_COOKIE_AGE)
             else:
-                request.session["session_refresh"] = int(time.time())
+                request.session["session_refresh"] = int(time())
         return self.get_response(request)
 
 
 class CustomRemoteUser(RemoteUserMiddleware):
+    """
+    Middleware used for remote authentication when `REVERSE_PROXY_AUTH` is True.
+    """
+
     header = getenv("PROXY_HEADER", "HTTP_REMOTE_USER")

--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -6,6 +6,12 @@ from django.conf import settings
 from django.utils import timezone, translation
 from django.conf.locale.en import formats as formats_en_us
 from django.conf.locale.en_GB import formats as formats_en_gb
+from os import getenv
+from django.contrib.auth.middleware import RemoteUserMiddleware
+
+
+class CustomRemoteUser(RemoteUserMiddleware):
+    header = getenv("PROXY_HEADER", "HTTP_REMOTE_USER")
 
 
 def update_en_us_date_formats():

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -12,6 +12,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 load_dotenv(find_dotenv())
 
+REVERSE_PROXY_AUTH = bool(int(os.getenv("REVERSE_PROXY_AUTH", False)))
+
 # Required settings
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
@@ -62,6 +64,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "axes.middleware.AxesMiddleware",
+    "babybuddy.middleware.CustomRemoteUser",
 ]
 
 
@@ -142,6 +145,12 @@ LOGIN_REDIRECT_URL = "babybuddy:root-router"
 LOGIN_URL = "babybuddy:login"
 
 LOGOUT_REDIRECT_URL = "babybuddy:login"
+
+# Only include when REVERSE_PROXY_AUTH env is 1
+if REVERSE_PROXY_AUTH:
+    # Must appear AFTER AuthenticationMiddleware
+    MIDDLEWARE.insert(6, "babybuddy.middleware.CustomRemoteUser")
+    AUTHENTICATION_BACKENDS.append("django.contrib.auth.backends.RemoteUserBackend")
 
 
 # Timezone

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -12,8 +12,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 load_dotenv(find_dotenv())
 
-REVERSE_PROXY_AUTH = bool(strtobool(os.environ.get("REVERSE_PROXY_AUTH") or "False"))
-
 # Required settings
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
@@ -145,10 +143,12 @@ LOGIN_URL = "babybuddy:login"
 
 LOGOUT_REDIRECT_URL = "babybuddy:login"
 
-# Only include when REVERSE_PROXY_AUTH env is 1
+REVERSE_PROXY_AUTH = bool(strtobool(os.environ.get("REVERSE_PROXY_AUTH") or "False"))
+
+# Use remote user middleware when reverse proxy auth is enabled.
 if REVERSE_PROXY_AUTH:
-    # Must appear AFTER AuthenticationMiddleware
-    MIDDLEWARE.insert(6, "babybuddy.middleware.CustomRemoteUser")
+    # Must appear AFTER AuthenticationMiddleware.
+    MIDDLEWARE.append("babybuddy.middleware.CustomRemoteUser")
     AUTHENTICATION_BACKENDS.append("django.contrib.auth.backends.RemoteUserBackend")
 
 

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -12,7 +12,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 load_dotenv(find_dotenv())
 
-REVERSE_PROXY_AUTH = bool(int(os.getenv("REVERSE_PROXY_AUTH", False)))
+REVERSE_PROXY_AUTH = bool(strtobool(os.environ.get("REVERSE_PROXY_AUTH") or "False"))
 
 # Required settings
 
@@ -64,7 +64,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "axes.middleware.AxesMiddleware",
-    "babybuddy.middleware.CustomRemoteUser",
 ]
 
 

--- a/babybuddy/tests/tests_reverse_proxy_auth.py
+++ b/babybuddy/tests/tests_reverse_proxy_auth.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from django.core.management import call_command
+from django.test import Client as HttpClient, TestCase, modify_settings
+
+
+class ReverseProxyAuthTestCase(TestCase):
+    """
+    Notes:
+        - A class method cannot be used to establish the HTTP client because of the
+          settings overrides required for these tests.
+        - Overriding the `REVERSE_PROXY_AUTH` environment variable directly is not
+          possible because environments variables are only evaluated once for the run.
+    """
+
+    def test_remote_user_authentication_disabled(self):
+        call_command("migrate", verbosity=0)
+        c = HttpClient()
+        response = c.get("/welcome/", HTTP_REMOTE_USER="admin", follow=True)
+        self.assertRedirects(response, "/login/?next=/welcome/")
+
+    @modify_settings(
+        MIDDLEWARE={"append": "babybuddy.middleware.CustomRemoteUser"},
+        AUTHENTICATION_BACKENDS={
+            "append": "django.contrib.auth.backends.RemoteUserBackend"
+        },
+    )
+    def test_remote_user_authentication_enabled(self):
+        call_command("migrate", verbosity=0)
+        c = HttpClient()
+        response = c.get("/welcome/", HTTP_REMOTE_USER="admin")
+        self.assertEqual(response.status_code, 200)

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -56,7 +56,7 @@ Sets the header to read the authenticated username from when
 
 ## `REVERSE_PROXY_AUTH`
 
-*Default:* `None`
+*Default:* `False`
 
 Enable use of `PROXY_HEADER` to pass the username of an authenticated user.
 This setting should *only* be used with a properly configured reverse proxy to

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -38,6 +38,34 @@ Each entry must contain both the scheme (http, https) and fully-qualified domain
 - [`ALLOWED_HOSTS`](#allowed_hosts)
 - [`SECURE_PROXY_SSL_HEADER`](#secure_proxy_ssl_header)
 
+## `PROXY_HEADER`
+
+*Default:* `HTTP_REMOTE_USER`
+
+Sets the header to read the authenticated username from when
+`REVERSE_PROXY_AUTH` has been enabled.
+
+**Example value**
+
+    HTTP_X_AUTH_USER
+
+**See also**
+
+- [Django's documentation on the `REMOTE_USER` authentication method](https://docs.djangoproject.com/en/4.1/howto/auth-remote-user/)
+- [`REVERSE_PROXY_AUTH`](#reverse_proxy_auth)
+
+## `REVERSE_PROXY_AUTH`
+
+*Default:* `None`
+
+Enable use of `PROXY_HEADER` to pass the username of an authenticated user.
+This setting should *only* be used with a properly configured reverse proxy to
+ensure the headers are not forwarded from sources other than your proxy.
+
+**See also**
+
+- [`PROXY_HEADER`](#proxy_header)
+
 ## `SECRET_KEY`
 
 *Default:* `None`


### PR DESCRIPTION
Implements feature requested in #517 

I tested the final state (containerized docker deployment) by modifying the LinuxServers.io Dockerfile to use my fork with the committed changes. The implementation works wonderfully. The username being passed in the header must exist in the system beforehand. If the header isn't received, authentication falls back to the login page. 