### PR TITLE
470 - "Recently used" shouldn't appear if no tags were recently used

### DIFF
--- a/core/templates/core/widget_tag_editor.html
+++ b/core/templates/core/widget_tag_editor.html
@@ -24,13 +24,21 @@
                 <button class="btn btn-outline-primary bg-dark btn-add-new-tag" type="button">{% trans "Add" %}</button>
             </div>
         </div>
-        <span>{% trans "Recently used:" %}</span>
-        {% for t in widget.tag_suggestions.quick %}
-        <span data-value="{{ t.name }}" data-color="{{ t.color }}" class="tag btn badge badge-pill cursor-pointer mr-1" style="background-color: {{ t.color }};">
-            {{ t.name }}
-            <span class="add-remove-icon pl-1 pr-1">+</span>
-        </span>
-        {% endfor %}
+        {% if widget.tag_suggestions.quick %}
+            <span>{% trans "Recently used:" %}</span>
+            {% for t in widget.tag_suggestions.quick %}
+            <span data-value="{{ t.name }}" data-color="{{ t.color }}" class="tag btn badge badge-pill cursor-pointer mr-1" style="background-color: {{ t.color }};">
+                {{ t.name }}
+                <span class="add-remove-icon pl-1 pr-1">+</span>
+            </span>
+            {% endfor %}
+        {% else %}
+            <style>
+                .help-block{
+                    display: none;
+                }
+            </style>
+        {%endif%}
     </div>
     <input 
         type="hidden"


### PR DESCRIPTION
Closes #470 

I have tried looking for a couple of solutions to avoid using inline CSS. However, since the logic is very generic, using inline CSS is the only way that worked. If the [div](https://github.com/babybuddy/babybuddy/blob/master/babybuddy/templates/babybuddy/form_field.html#L44) that showed `help_text` was in the same file as the [widget tag editor](https://github.com/babybuddy/babybuddy/blob/master/core/templates/core/widget_tag_editor.html#L27), I could have conditionally added a class to the div and hide it inside the custom CSS files, but that's not the case. Anyways maybe I'm missing something here. I would like to know if there is another better way.