### PR TITLE
#468  Minutes instead of minutos in Spanish

### DIFF
--- a/core/templatetags/duration.py
+++ b/core/templatetags/duration.py
@@ -33,7 +33,7 @@ def child_age_string(birth_date):
 def duration_string(duration, precision="s"):
     """
     Format a duration (e.g. "2 hours, 3 minutes, 35 seconds").
-    :param duration: a timedetla instance.
+    :param duration: a timedelta instance.
     :param precision: the level of precision to return (h for hours, m for
                       minutes, s for seconds)
     :returns: a string representation of the duration.
@@ -50,7 +50,7 @@ def duration_string(duration, precision="s"):
 def hours(duration):
     """
     Return the "hours" portion of a duration.
-    :param duration: a timedetla instance.
+    :param duration: a timedelta instance.
     :returns: an integer representing the number of hours in duration.
     """
     if not duration:
@@ -66,7 +66,7 @@ def hours(duration):
 def minutes(duration):
     """
     Return the "minutes" portion of a duration.
-    :param duration: a timedetla instance.
+    :param duration: a timedelta instance.
     :returns: an integer representing the number of minutes in duration.
     """
     if not duration:
@@ -82,7 +82,7 @@ def minutes(duration):
 def seconds(duration):
     """
     Return the "seconds" portion of a duration.
-    :param duration: a timedetla instance.
+    :param duration: a timedelta instance.
     :returns: an integer representing the number of seconds in duration.
     """
     if not duration:
@@ -114,3 +114,19 @@ def dayssince(value, today=None):
 
     # use standard timesince for anything beyond yesterday
     return str(delta.days) + _(" days ago")
+
+
+@register.filter
+def deltasince(value, now=None):
+    """
+    Returns a timedelta representing the time since passed datetime
+    :param value: a datetime instance
+    :param now: datetime to compare to (defaults to now)
+    :returns: a timedelta representing the elapsed time
+    """
+    if now is None:
+        now = timezone.now()
+
+    delta = now - value
+
+    return delta

--- a/core/tests/tests_templatetags.py
+++ b/core/tests/tests_templatetags.py
@@ -95,6 +95,26 @@ class TemplateTagsTestCase(TestCase):
                 "60 days ago",
             )
 
+    def test_duration_deltasince(self):
+        datetimes = [
+            (
+                timezone.datetime(2022, 1, 1, 0, 0, 1),
+                timezone.timedelta(seconds=1),
+            ),  # new year
+            (
+                timezone.datetime(2021, 12, 31, 23, 59, 59),
+                timezone.timedelta(seconds=3),
+            ),  # almost new year
+            (
+                timezone.datetime(1969, 2, 1, 23, 59, 59),
+                timezone.timedelta(days=19326, seconds=3),
+            ),  # old but middle of the year
+        ]
+        now = timezone.datetime(2022, 1, 1, 0, 0, 2)
+        for d, expected_delta in datetimes:
+            with self.subTest():
+                self.assertEqual(duration.deltasince(d, now), expected_delta)
+
     def test_instance_add_url(self):
         child = Child.objects.create(
             first_name="Test", last_name="Child", birth_date=timezone.localdate()

--- a/dashboard/templates/cards/diaperchange_last.html
+++ b/dashboard/templates/cards/diaperchange_last.html
@@ -1,5 +1,5 @@
 {% extends 'cards/base.html' %}
-{% load i18n %}
+{% load duration i18n %}
 
 {% block header %}
     <a href="{% url "core:diaperchange-list" %}">
@@ -9,7 +9,7 @@
 
 {% block title %}
     {% if change %}
-        {% blocktrans trimmed with since=change.time|timesince time=change.time|time %}
+        {% blocktrans trimmed with since=change.time|deltasince|duration_string:'m' time=change.time|time %}
             <div>{{ since }} ago</div>
             <small>{{ time }}</small>
         {% endblocktrans %}

--- a/dashboard/templates/cards/feeding_last.html
+++ b/dashboard/templates/cards/feeding_last.html
@@ -1,5 +1,5 @@
 {% extends 'cards/base.html' %}
-{% load i18n %}
+{% load duration i18n %}
 
 {% block header %}
     <a href="{% url "core:feeding-list" %}">
@@ -9,7 +9,7 @@
 
 {% block title %}
     {% if feeding %}
-        {% blocktrans trimmed with since=feeding.start|timesince time=feeding.start|time %}
+        {% blocktrans trimmed with since=feeding.start|deltasince|duration_string:'m' time=feeding.start|time %}
             <div>{{ since }} ago</div>
             <small>{{ time }}</small>
         {% endblocktrans %}

--- a/dashboard/templates/cards/sleep_last.html
+++ b/dashboard/templates/cards/sleep_last.html
@@ -9,7 +9,7 @@
 
 {% block title %}
     {% if sleep %}
-        {% blocktrans trimmed with since=sleep.end|timesince time=sleep.end|time %}
+        {% blocktrans trimmed with since=sleep.end|deltasince|duration_string:'m' time=sleep.end|time %}
             <div>{{ since }} ago</div>
             <small>{{ time }}</small>
         {% endblocktrans %}

--- a/dashboard/templates/cards/tummytime_last.html
+++ b/dashboard/templates/cards/tummytime_last.html
@@ -10,7 +10,7 @@
 
 {% block title %}
     {% if tummytime %}
-        {% blocktrans trimmed with since=tummytime.time|timesince time=tummytime.time|time %}
+        {% blocktrans trimmed with since=tummytime.time|deltasince|duration_string:'m' time=tummytime.time|time %}
             <div>{{ since }} ago</div>
             <small>{{ time }}</small>
         {% endblocktrans %}


### PR DESCRIPTION
Closes #468 

# Background

Users noticed that in the home cards in the Spanish version instead of "minutos" babybuddy shows "minutes". Upon further investigation, we noticed that "minuto" is also misspelled as "minutos" in Spanish and Portuguese is also affected by the bug.

The root cause of this issue are incorrect translations in Django. PO files for Spanish and Portuguese use either the wrong format or have been wrongly translated. As a workaround, it was suggested that we use `duration_string`.

Since `duration_string` string expects a `timedelta`, a new filter to get the duration as a `timedelta` was added (since I could not find an existing, straightforward function to use, the closes was `timesince` which returns a `str`).

# Changes

* Add `deltasince`, a new filter that calculates duration and returns a timedelta.
* Update *_last.html templates to use `deltasince` followed by `duration_string` (with `m`inutes precision) instead of `timesince`.
* Add a test for `deltasince`.
* Fix a typo in `duration.py`.

Spanish:
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/48921408/194994871-8f008110-a9e9-4b0c-aef3-ccfc605525cd.png">

Portuguese:
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/48921408/194994936-bc04d0ad-7993-4f6e-a535-5caa1aec845e.png">

Italian (this one already worked, adding it as a proof that other languages did not break):
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/48921408/194994991-a0212963-ca1c-4562-93d6-93bc6e430496.png">
