### PR TITLE
Allow setting `CSRF_COOKIE_SECURE` and `SESSION_COOKIE_SECURE` via env vars

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -268,11 +268,11 @@ if os.environ.get("SECURE_PROXY_SSL_HEADER"):
 
 # https://docs.djangoproject.com/en/4.0/topics/http/sessions/#settings
 SESSION_COOKIE_HTTPONLY = True
-# SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = bool(strtobool(os.environ.get("SESSION_COOKIE_SECURE") or "False"))
 
 # https://docs.djangoproject.com/en/4.0/ref/csrf/#settings
 CSRF_COOKIE_HTTPONLY = True
-# CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = bool(strtobool(os.environ.get("CSRF_COOKIE_SECURE") or "False"))
 CSRF_FAILURE_VIEW = "babybuddy.views.csrf_failure"
 CSRF_TRUSTED_ORIGINS = list(
     filter(None, os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(","))

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -268,7 +268,9 @@ if os.environ.get("SECURE_PROXY_SSL_HEADER"):
 
 # https://docs.djangoproject.com/en/4.0/topics/http/sessions/#settings
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SECURE = bool(strtobool(os.environ.get("SESSION_COOKIE_SECURE") or "False"))
+SESSION_COOKIE_SECURE = bool(
+    strtobool(os.environ.get("SESSION_COOKIE_SECURE") or "False")
+)
 
 # https://docs.djangoproject.com/en/4.0/ref/csrf/#settings
 CSRF_COOKIE_HTTPONLY = True

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -19,6 +19,15 @@ Do not include schemes ("http" or "https") with this setting.
 - [`CSRF_TRUSTED_ORIGINS`](#csrf_trusted_origins)
 - [`SECURE_PROXY_SSL_HEADER`](#secure_proxy_ssl_header)
 
+## `CSRF_COOKIE_SECURE`
+
+*Default:* `False`
+
+If this is set to `True`, the browser CSRF cookie will be marked as "secure", which instructs the browser to only send the cookie over an HTTPS connection (never HTTP).
+
+**See also**
+- [Django's documentation on the `CSRF_COOKIE_SECURE` setting](https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-cookie-secure)
+
 ## `CSRF_TRUSTED_ORIGINS`
 
 *Default:* `None`
@@ -89,3 +98,12 @@ came in via HTTPS).
 - [Django's documentation on the SECURE_PROXY_SSL_HEADER setting](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-proxy-ssl-header)
 - [`ALLOWED_HOSTS`](#allowed_hosts)
 - [`CSRF_TRUSTED_ORIGINS`](#csrf_trusted_origins)
+
+## `SESSION_COOKIE_SECURE`
+
+*Default:* `False`
+
+If this is set to `True`, the browser session cookie will be marked as "secure", which instructs the browser to only send the cookie over an HTTPS connection (never HTTP).
+
+**See also**
+- [Django's documentation on the `SESSION_COOKIE_SECURE` setting](https://docs.djangoproject.com/en/4.0/ref/settings/#session-cookie-secure)


### PR DESCRIPTION
Added support and docs for setting `CSRF_COOKIE_SECURE` and `SESSION_COOKIE_SECURE` via env vars.

(It was possible to do this before with a custom settings module, but getting that configured, especially when running via Docker, is a lot of work compared to just setting an environment variable.)