### PR TITLE
Use Django's floatformat on today's feeding total

### DIFF
--- a/dashboard/templates/cards/feeding_day.html
+++ b/dashboard/templates/cards/feeding_day.html
@@ -15,7 +15,7 @@
             <div class="carousel-item{% if forloop.counter == 1 %} active{% endif %}">
                 <div class="last-feeding-method text-center">
                     {% if feeding.total %}
-                        {{ feeding.total }}
+                        {{ feeding.total|floatformat }}
                     {% else %}
                         {% trans "None" %}
                     {% endif %}


### PR DESCRIPTION
Fixes #595 

Uses Django's `floatformat` on the total feeding amount.

Note: As per the discussion on the linked issue, we should probably add this filter to other areas.  I'm open to adding them if there's a handful of quick knowns, but not sure immediately where they are.