### PR TITLE
Add DRF's OrderingFilter to list of default filter backends to implement ordering in the API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -16,6 +16,8 @@ class BMIViewSet(viewsets.ModelViewSet):
     queryset = models.BMI.objects.all()
     serializer_class = serializers.BMISerializer
     filterset_fields = ("child", "date")
+    ordering_fields = ("child", "date")
+    ordering = "-date"
 
     def get_view_name(self):
         """
@@ -32,48 +34,64 @@ class ChildViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.ChildSerializer
     lookup_field = "slug"
     filterset_fields = ("first_name", "last_name", "slug", "birth_date")
+    ordering_fields = ("birth_date", "first_name", "last_name", "slug")
+    ordering = "-birth_date"
 
 
 class DiaperChangeViewSet(viewsets.ModelViewSet):
     queryset = models.DiaperChange.objects.all()
     serializer_class = serializers.DiaperChangeSerializer
     filterset_class = filters.DiaperChangeFilter
+    ordering_fields = ("amount", "time")
+    ordering = "-time"
 
 
 class FeedingViewSet(viewsets.ModelViewSet):
     queryset = models.Feeding.objects.all()
     serializer_class = serializers.FeedingSerializer
     filterset_class = filters.FeedingFilter
+    ordering_fields = ("amount", "duration", "end", "start")
+    ordering = "-end"
 
 
 class HeadCircumferenceViewSet(viewsets.ModelViewSet):
     queryset = models.HeadCircumference.objects.all()
     serializer_class = serializers.HeadCircumferenceSerializer
     filterset_fields = ("child", "date")
+    ordering_fields = ("date", "head_circumference")
+    ordering = "-date"
 
 
 class HeightViewSet(viewsets.ModelViewSet):
     queryset = models.Height.objects.all()
     serializer_class = serializers.HeightSerializer
     filterset_fields = ("child", "date")
+    ordering_fields = ("date", "height")
+    ordering = "-date"
 
 
 class NoteViewSet(viewsets.ModelViewSet):
     queryset = models.Note.objects.all()
     serializer_class = serializers.NoteSerializer
     filterset_class = filters.NoteFilter
+    ordering_fields = "time"
+    ordering = "-time"
 
 
 class PumpingViewSet(viewsets.ModelViewSet):
     queryset = models.Pumping.objects.all()
     serializer_class = serializers.PumpingSerializer
     filterset_class = filters.PumpingFilter
+    ordering_fields = ("amount", "time")
+    ordering = "-time"
 
 
 class SleepViewSet(viewsets.ModelViewSet):
     queryset = models.Sleep.objects.all()
     serializer_class = serializers.SleepSerializer
     filterset_class = filters.SleepFilter
+    ordering_fields = ("duration", "end", "start")
+    ordering = "-end"
 
 
 class TagViewSet(viewsets.ModelViewSet):
@@ -81,18 +99,24 @@ class TagViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.TagSerializer
     lookup_field = "slug"
     filterset_fields = ("last_used", "name")
+    ordering_fields = ("last_used", "name", "slug")
+    ordering = "name"
 
 
 class TemperatureViewSet(viewsets.ModelViewSet):
     queryset = models.Temperature.objects.all()
     serializer_class = serializers.TemperatureSerializer
     filterset_class = filters.TemperatureFilter
+    ordering_fields = ("temperature", "time")
+    ordering = "-time"
 
 
 class TimerViewSet(viewsets.ModelViewSet):
     queryset = models.Timer.objects.all()
     serializer_class = serializers.TimerSerializer
     filterset_class = filters.TimerFilter
+    ordering_fields = ("duration", "end", "start")
+    ordering = "-start"
 
     @action(detail=True, methods=["patch"])
     def stop(self, request, pk=None):
@@ -111,12 +135,16 @@ class TummyTimeViewSet(viewsets.ModelViewSet):
     queryset = models.TummyTime.objects.all()
     serializer_class = serializers.TummyTimeSerializer
     filterset_class = filters.TummyTimeFilter
+    ordering_fields = ("duration", "end", "start")
+    ordering = "-start"
 
 
 class WeightViewSet(viewsets.ModelViewSet):
     queryset = models.Weight.objects.all()
     serializer_class = serializers.WeightSerializer
     filterset_fields = ("child", "date")
+    ordering_fields = ("date", "weight")
+    ordering = "-date"
 
 
 class ProfileView(views.APIView):

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -310,6 +310,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_FILTER_BACKENDS": [
         "django_filters.rest_framework.DjangoFilterBackend",
+        "rest_framework.filters.OrderingFilter",
     ],
     "DEFAULT_METADATA_CLASS": "api.metadata.APIMetadata",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",

--- a/openapi-schema.yml
+++ b/openapi-schema.yml
@@ -32,6 +32,12 @@ paths:
         description: date
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -106,48 +112,12 @@ paths:
         description: date
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BMI'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateBMI
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this BMI.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: date
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BMI'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/BMI'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/BMI'
       responses:
         '200':
           content:
@@ -177,6 +147,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -219,6 +195,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -300,6 +282,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -423,95 +411,12 @@ paths:
         description: tag
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DiaperChange'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateDiaperChange
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Diaper Change.
-        schema:
-          type: string
-      - name: amount
+      - name: ordering
         required: false
         in: query
-        description: amount
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: child
-        required: false
-        in: query
-        description: child
-        schema:
-          type: string
-      - name: color
-        required: false
-        in: query
-        description: color
-        schema:
-          type: string
-          enum:
-          - black
-          - brown
-          - green
-          - yellow
-      - name: date
-        required: false
-        in: query
-        description: DateTime
-        schema:
-          type: string
-      - name: date_max
-        required: false
-        in: query
-        description: Max. DateTime
-        schema:
-          type: string
-      - name: date_min
-        required: false
-        in: query
-        description: Min. DateTime
-        schema:
-          type: string
-      - name: solid
-        required: false
-        in: query
-        description: solid
-        schema:
-          type: string
-      - name: wet
-        required: false
-        in: query
-        description: wet
-        schema:
-          type: string
-      - name: tags
-        required: false
-        in: query
-        description: tag
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DiaperChange'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/DiaperChange'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/DiaperChange'
       responses:
         '200':
           content:
@@ -588,6 +493,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -679,6 +590,12 @@ paths:
         description: tag
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -723,6 +640,12 @@ paths:
         required: false
         in: query
         description: birth_date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -811,60 +734,12 @@ paths:
         description: birth_date
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Child'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateChild
-      description: ''
-      parameters:
-      - name: slug
-        in: path
-        required: true
-        description: ''
-        schema:
-          type: string
-      - name: first_name
+      - name: ordering
         required: false
         in: query
-        description: first_name
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: last_name
-        required: false
-        in: query
-        description: last_name
-        schema:
-          type: string
-      - name: slug
-        required: false
-        in: query
-        description: slug
-        schema:
-          type: string
-      - name: birth_date
-        required: false
-        in: query
-        description: birth_date
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Child'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Child'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Child'
       responses:
         '200':
           content:
@@ -906,6 +781,12 @@ paths:
         required: false
         in: query
         description: birth_date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -960,6 +841,12 @@ paths:
         required: false
         in: query
         description: birth_date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -1054,6 +941,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -1190,108 +1083,12 @@ paths:
         description: tag
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Feeding'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateFeeding
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Feeding.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: end
-        required: false
-        in: query
-        description: End DateTime
-        schema:
-          type: string
-      - name: end_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: end_min
-        required: false
-        in: query
-        description: Min. End DateTime
-        schema:
-          type: string
-      - name: method
-        required: false
-        in: query
-        description: method
-        schema:
-          type: string
-          enum:
-          - bottle
-          - left breast
-          - right breast
-          - both breasts
-          - parent fed
-          - self fed
-      - name: start
-        required: false
-        in: query
-        description: Start DateTime
-        schema:
-          type: string
-      - name: start_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: start_min
-        required: false
-        in: query
-        description: Min. Start DateTime
-        schema:
-          type: string
-      - name: type
-        required: false
-        in: query
-        description: type
-        schema:
-          type: string
-          enum:
-          - breast milk
-          - formula
-          - fortified breast milk
-          - solid food
-      - name: tags
-        required: false
-        in: query
-        description: tag
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Feeding'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Feeding'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Feeding'
       responses:
         '200':
           content:
@@ -1381,6 +1178,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -1485,6 +1288,12 @@ paths:
         description: tag
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -1517,6 +1326,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -1593,48 +1408,12 @@ paths:
         description: date
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HeadCircumference'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateHeadCircumference
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Head Circumference.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: date
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/HeadCircumference'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/HeadCircumference'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/HeadCircumference'
       responses:
         '200':
           content:
@@ -1664,6 +1443,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -1708,6 +1493,12 @@ paths:
         description: date
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -1740,6 +1531,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -1816,48 +1613,12 @@ paths:
         description: date
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Height'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateHeight
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Height.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: date
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Height'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Height'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Height'
       responses:
         '200':
           content:
@@ -1887,6 +1648,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -1929,6 +1696,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -1981,6 +1754,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -2075,66 +1854,12 @@ paths:
         description: tag
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Note'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateNote
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Note.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: DateTime
-        schema:
-          type: string
-      - name: date_max
-        required: false
-        in: query
-        description: Max. DateTime
-        schema:
-          type: string
-      - name: date_min
-        required: false
-        in: query
-        description: Min. DateTime
-        schema:
-          type: string
-      - name: tags
-        required: false
-        in: query
-        description: tag
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Note'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Note'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Note'
       responses:
         '200':
           content:
@@ -2182,6 +1907,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -2244,6 +1975,12 @@ paths:
         description: tag
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -2288,6 +2025,12 @@ paths:
         required: false
         in: query
         description: Min. DateTime
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -2376,60 +2119,12 @@ paths:
         description: Min. DateTime
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pumping'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updatePumping
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Pumping.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: DateTime
-        schema:
-          type: string
-      - name: date_max
-        required: false
-        in: query
-        description: Max. DateTime
-        schema:
-          type: string
-      - name: date_min
-        required: false
-        in: query
-        description: Min. DateTime
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Pumping'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Pumping'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Pumping'
       responses:
         '200':
           content:
@@ -2471,6 +2166,12 @@ paths:
         required: false
         in: query
         description: Min. DateTime
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -2525,6 +2226,12 @@ paths:
         required: false
         in: query
         description: Min. DateTime
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -2595,6 +2302,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -2707,84 +2420,12 @@ paths:
         description: tag
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Sleep'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateSleep
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Sleep.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: end
-        required: false
-        in: query
-        description: End DateTime
-        schema:
-          type: string
-      - name: end_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: end_min
-        required: false
-        in: query
-        description: Min. End DateTime
-        schema:
-          type: string
-      - name: start
-        required: false
-        in: query
-        description: Start DateTime
-        schema:
-          type: string
-      - name: start_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: start_min
-        required: false
-        in: query
-        description: Min. Start DateTime
-        schema:
-          type: string
-      - name: tags
-        required: false
-        in: query
-        description: tag
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Sleep'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Sleep'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Sleep'
       responses:
         '200':
           content:
@@ -2850,6 +2491,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -2930,6 +2577,12 @@ paths:
         description: tag
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -2962,6 +2615,12 @@ paths:
         required: false
         in: query
         description: name
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -3038,48 +2697,12 @@ paths:
         description: name
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Tag'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateTag
-      description: ''
-      parameters:
-      - name: slug
-        in: path
-        required: true
-        description: ''
-        schema:
-          type: string
-      - name: last_used
+      - name: ordering
         required: false
         in: query
-        description: last_used
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: name
-        required: false
-        in: query
-        description: name
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Tag'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Tag'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Tag'
       responses:
         '200':
           content:
@@ -3109,6 +2732,12 @@ paths:
         required: false
         in: query
         description: name
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -3151,6 +2780,12 @@ paths:
         required: false
         in: query
         description: name
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -3203,6 +2838,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -3297,66 +2938,12 @@ paths:
         description: tag
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Temperature'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateTemperature
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Temperature.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: DateTime
-        schema:
-          type: string
-      - name: date_max
-        required: false
-        in: query
-        description: Max. DateTime
-        schema:
-          type: string
-      - name: date_min
-        required: false
-        in: query
-        description: Min. DateTime
-        schema:
-          type: string
-      - name: tags
-        required: false
-        in: query
-        description: tag
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Temperature'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Temperature'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Temperature'
       responses:
         '200':
           content:
@@ -3404,6 +2991,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -3464,6 +3057,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -3540,6 +3139,12 @@ paths:
         required: false
         in: query
         description: user
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -3658,90 +3263,12 @@ paths:
         description: user
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Timer'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateTimer
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Timer.
-        schema:
-          type: string
-      - name: active
+      - name: ordering
         required: false
         in: query
-        description: active
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: child
-        required: false
-        in: query
-        description: child
-        schema:
-          type: string
-      - name: end
-        required: false
-        in: query
-        description: End DateTime
-        schema:
-          type: string
-      - name: end_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: end_min
-        required: false
-        in: query
-        description: Min. End DateTime
-        schema:
-          type: string
-      - name: start
-        required: false
-        in: query
-        description: Start DateTime
-        schema:
-          type: string
-      - name: start_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: start_min
-        required: false
-        in: query
-        description: Min. Start DateTime
-        schema:
-          type: string
-      - name: user
-        required: false
-        in: query
-        description: user
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Timer'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Timer'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Timer'
       responses:
         '200':
           content:
@@ -3813,6 +3340,12 @@ paths:
         required: false
         in: query
         description: user
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -3899,6 +3432,12 @@ paths:
         description: user
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -3967,6 +3506,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -4079,84 +3624,12 @@ paths:
         description: tag
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TummyTime'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateTummyTime
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Tummy Time.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: end
-        required: false
-        in: query
-        description: End DateTime
-        schema:
-          type: string
-      - name: end_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: end_min
-        required: false
-        in: query
-        description: Min. End DateTime
-        schema:
-          type: string
-      - name: start
-        required: false
-        in: query
-        description: Start DateTime
-        schema:
-          type: string
-      - name: start_max
-        required: false
-        in: query
-        description: Max. End DateTime
-        schema:
-          type: string
-      - name: start_min
-        required: false
-        in: query
-        description: Min. Start DateTime
-        schema:
-          type: string
-      - name: tags
-        required: false
-        in: query
-        description: tag
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TummyTime'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/TummyTime'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TummyTime'
       responses:
         '200':
           content:
@@ -4222,6 +3695,12 @@ paths:
         required: false
         in: query
         description: tag
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -4302,6 +3781,12 @@ paths:
         description: tag
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       responses:
         '204':
           description: ''
@@ -4334,6 +3819,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -4410,48 +3901,12 @@ paths:
         description: date
         schema:
           type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Weight'
-          description: ''
-      tags:
-      - api
-    put:
-      operationId: updateWeight
-      description: ''
-      parameters:
-      - name: id
-        in: path
-        required: true
-        description: A unique integer value identifying this Weight.
-        schema:
-          type: string
-      - name: child
+      - name: ordering
         required: false
         in: query
-        description: child
+        description: Which field to use when ordering the results.
         schema:
           type: string
-      - name: date
-        required: false
-        in: query
-        description: date
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Weight'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Weight'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Weight'
       responses:
         '200':
           content:
@@ -4481,6 +3936,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       requestBody:
@@ -4523,6 +3984,12 @@ paths:
         required: false
         in: query
         description: date
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       responses:
@@ -4624,7 +4091,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - bmi
@@ -4657,7 +4126,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - wet
@@ -4714,6 +4185,7 @@ components:
         duration:
           type: string
           readOnly: true
+          nullable: true
         type:
           enum:
           - breast milk
@@ -4737,7 +4209,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - type
       - method
@@ -4758,7 +4232,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - head_circumference
@@ -4779,7 +4255,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - height
@@ -4797,7 +4275,9 @@ components:
           type: string
           format: date-time
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - note
@@ -4817,6 +4297,10 @@ components:
         notes:
           type: string
           nullable: true
+        tags:
+          type: array
+          items:
+            type: string
       required:
       - child
       - amount
@@ -4847,6 +4331,7 @@ components:
         duration:
           type: string
           readOnly: true
+          nullable: true
         nap:
           type: string
           readOnly: true
@@ -4854,7 +4339,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
     Tag:
       type: object
       properties:
@@ -4892,7 +4379,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - temperature
@@ -4916,9 +4405,11 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         duration:
           type: string
           readOnly: true
+          nullable: true
         active:
           type: boolean
           readOnly: true
@@ -4951,11 +4442,14 @@ components:
         duration:
           type: string
           readOnly: true
+          nullable: true
         milestone:
           type: string
           maxLength: 255
         tags:
-          type: string
+          type: array
+          items:
+            type: string
     Weight:
       type: object
       properties:
@@ -4973,7 +4467,9 @@ components:
           type: string
           nullable: true
         tags:
-          type: string
+          type: array
+          items:
+            type: string
       required:
       - child
       - weight


### PR DESCRIPTION
Issue: #588 

This adds DRF's `OrderingFilter` to the default list of filter backends, which allows us to include an `ordering` parameter in API requests.  AFAICT in the docs, this allows us to order on any fields that are in the serializer.

If we want to restrict that further, it's possible, but this felt like a good start.