### PR TITLE
Add `id` to filter fields for children-api endpoint

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -33,7 +33,7 @@ class ChildViewSet(viewsets.ModelViewSet):
     queryset = models.Child.objects.all()
     serializer_class = serializers.ChildSerializer
     lookup_field = "slug"
-    filterset_fields = ("first_name", "last_name", "slug", "birth_date")
+    filterset_fields = ("id", "first_name", "last_name", "slug", "birth_date")
     ordering_fields = ("birth_date", "first_name", "last_name", "slug")
     ordering = "-birth_date"
 


### PR DESCRIPTION
## Background

The api endpoint `http://localhost:8888/api/children/` right now uses the slug of a child to do a detail query, while most filter-options for activities (tummy-time, use the child-id to implement filtering.

I have encountered a bug in the Android App I am developing for which it would be handy to do a quick check for the existence of a child. It is kind of awkward to have to use the slug for this while I use a child-id for all other types of queries. 

## Solution

To allow for a quick "exists"-check against the database, I added the "id" flag to the filterset-fields to allow `http://localhost:8888/api/children/?id=xxx` which will solve this issue. Less awkward than traversing a potentially super-long list of child-items just to find the one you are looking for...
