### PR TITLE
Fix dependency for hand-written migration 0028

### DIFF
--- a/core/migrations/0028_alter_sleep_options_remove_sleep_napping_sleep_nap.py
+++ b/core/migrations/0028_alter_sleep_options_remove_sleep_napping_sleep_nap.py
@@ -20,6 +20,7 @@ def set_sleep_nap_values(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("core", "0027_alter_timer_options_remove_timer_duration_and_more"),
+        ("dbsettings", "0001_initial"),
     ]
 
     operations = [


### PR DESCRIPTION
Fixes #644 (see over there for details)

The migration `core/migrations/0028_alter_sleep_options_remove_sleep_napping_sleep_nap.py` requires the `dbsettings`-table (also new) to be populated first. Adding the dependency fixes the issue.