### PR TITLE
display 0 minutes ago on dashboard when event is less than 1 minute old

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -38,7 +38,7 @@ def duration_string(duration, precision="s"):
     duration = ""
     if h > 0:
         duration = ngettext("%(hours)s hour", "%(hours)s hours", h) % {"hours": h}
-    if m > 0 and precision != "h":
+    if m >= 0 and precision != "h":
         if duration != "":
             duration += ", "
         duration += ngettext("%(minutes)s minute", "%(minutes)s minutes", m) % {


### PR DESCRIPTION
Fixes https://github.com/babybuddy/babybuddy/issues/628

![babybuddy](https://github.com/babybuddy/babybuddy/assets/76965771/97136600-8a88-4ebe-bdf6-5be7131e7f87)
