### PR TITLE
Add Pumping link to quick-add in navbar 

### DIFF
--- a/babybuddy/templates/babybuddy/nav-dropdown.html
+++ b/babybuddy/templates/babybuddy/nav-dropdown.html
@@ -52,6 +52,12 @@
                                 {% trans "Feeding" %}
                             </a>
                         {% endif %}
+                        {% if perms.core.add_pumping %}
+                            <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
+                                <i class="icon-pumping" aria-hidden="true"></i>
+                                {% trans "Pumping" %}
+                            </a>
+                        {% endif %}
                         {% if perms.core.add_note %}
                             <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
                                 <i class="icon-note" aria-hidden="true"></i>


### PR DESCRIPTION
While using the app my wife noticed there is no 'quick-add' option for Pumping entries in the compact/mobile-friendly layout. 

As best I can tell, this is as simple as adding an entry in the template file: `babybuddy/templates/babybuddy/nav-dropdown.html`.

I've created the dev environment and checked that the added link redirects to the pumping form, as well as run `gulp test` - but this is my first contribution here so please let me know if I've missed anything.