### PR TITLE
Use homeassistant X-Ingress-Path for building paths, expose ingress_session

### DIFF
--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -98,9 +98,9 @@ class HomeAssistant:
 
     def __call__(self, request: HttpRequest):
         def wrap_x_ingress_path(org_func):
-            if request.headers.get("HTTP_X_HASS_SOURCE") != "core.ingress":
+            if not request.is_homeassistant_ingress_request:
                 return org_func
-            x_ingress_path = request.headers.get("HTTP_X_INGRESS_PATH")
+            x_ingress_path = request.headers.get("X-Ingress-Path")
             if x_ingress_path is None:
                 return org_func
 
@@ -114,6 +114,10 @@ class HomeAssistant:
 
                 return url
             return wrapper
+
+        request.is_homeassistant_ingress_request = (
+            request.headers.get("X-Hass-Source") == "core.ingress"
+        )
 
         if self.use_x_ingress_path_rewrite:
             request.build_absolute_uri = wrap_x_ingress_path(

--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -10,6 +10,7 @@ from django.utils import timezone, translation
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.http import HttpRequest
 
+
 class UserLanguageMiddleware:
     """
     Customizes settings based on user language setting.
@@ -97,17 +98,17 @@ class HomeAssistant:
     Django middleware that adds HomeAssistant specific properties and checks
     to the request-object.
 
-    The middleware is only active if the settings variable 
+    The middleware is only active if the settings variable
     `ENABLE_HOME_ASSISTANT_SUPPORT` is set to True. Note that some features
-    remain enabled even if the middleware is set to inactive through the 
+    remain enabled even if the middleware is set to inactive through the
     settings.
 
     Features:
-    
+
     - request.is_homeassistant_ingress_request (bool)
 
         Indicates if a request was rerouted through the home assistant ingress
-        service. This parameters is always present regardless of the 
+        service. This parameters is always present regardless of the
         ENABLE_HOME_ASSISTANT_SUPPORT settings option. It defaults to false
         if the middleware is disabled.
 
@@ -139,11 +140,10 @@ class HomeAssistant:
                     url_parts._replace(path=x_ingress_path + url_parts.path)
                 )
                 return url
+
             return wrapper
 
-        request.build_absolute_uri = wrap_x_ingress_path(
-            request.build_absolute_uri
-        )
+        request.build_absolute_uri = wrap_x_ingress_path(request.build_absolute_uri)
 
     def __call__(self, request: HttpRequest):
         if self.home_assistant_support_enabled:
@@ -156,4 +156,3 @@ class HomeAssistant:
         self.__wrap_build_absolute_uri(request)
 
         return self.get_response(request)
-    

--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -9,6 +9,7 @@ from django.utils import timezone, translation
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.http import HttpRequest
 
+
 class UserLanguageMiddleware:
     """
     Customizes settings based on user language setting.
@@ -113,6 +114,7 @@ class HomeAssistant:
                 )
 
                 return url
+
             return wrapper
 
         request.is_homeassistant_ingress_request = (
@@ -120,10 +122,6 @@ class HomeAssistant:
         )
 
         if self.use_x_ingress_path_rewrite:
-            request.build_absolute_uri = wrap_x_ingress_path(
-                request.build_absolute_uri
-            )
+            request.build_absolute_uri = wrap_x_ingress_path(request.build_absolute_uri)
 
         return self.get_response(request)
-
-    

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -361,4 +361,4 @@ BABY_BUDDY = {
 
 # Home assistant specific configuration
 
-HOME_ASSISTANT_USE_X_INGRESS_PATH = False
+ENABLE_HOME_ASSISTANT_SUPPORT = False

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -361,4 +361,6 @@ BABY_BUDDY = {
 
 # Home assistant specific configuration
 
-ENABLE_HOME_ASSISTANT_SUPPORT = False
+ENABLE_HOME_ASSISTANT_SUPPORT = bool(
+    strtobool(os.environ.get("ENABLE_HOME_ASSISTANT_SUPPORT") or "False")
+)

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "axes.middleware.AxesMiddleware",
+    "babybuddy.middleware.HomeAssistant",
 ]
 
 
@@ -351,9 +352,13 @@ ROLLING_SESSION_REFRESH = 86400
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Baby Buddy configuration
-# See README.md#configuration for details about these settings.
+# See https://docs.baby-buddy.net/ for details about these settings.
 
 BABY_BUDDY = {
     "ALLOW_UPLOADS": bool(strtobool(os.environ.get("ALLOW_UPLOADS") or "True")),
     "READ_ONLY_GROUP_NAME": "read_only",
 }
+
+# Home assistant specific configuration
+
+HOME_ASSISTANT_USE_X_INGRESS_PATH = False

--- a/babybuddy/settings/test.py
+++ b/babybuddy/settings/test.py
@@ -24,3 +24,7 @@ AXES_ENABLED = False
 # See https://github.com/zlorf/django-dbsettings#a-note-about-caching
 
 DBSETTINGS_USE_CACHE = False
+
+# We want to test the home assistant middleware
+
+ENABLE_HOME_ASSISTANT_SUPPORT = True

--- a/babybuddy/templates/babybuddy/login_qr_code.txt
+++ b/babybuddy/templates/babybuddy/login_qr_code.txt
@@ -1,4 +1,4 @@
 {% load i18n widget_tweaks babybuddy qr_code %}
 {% url 'babybuddy:root-router' as relative_root_url %}
 {% make_absolute_url relative_root_url as absolute_root_url %}
-BABYBUDDY-LOGIN:{"url":"{{ absolute_root_url }}","api_key":"{{ user.settings.api_key }}","session-cookie":"{{ session_cookie }}"}
+BABYBUDDY-LOGIN:{"url":"{{ absolute_root_url }}","api_key":"{{ user.settings.api_key }}","session_cookies":{{ session_cookies|safe }}}

--- a/babybuddy/templates/babybuddy/login_qr_code.txt
+++ b/babybuddy/templates/babybuddy/login_qr_code.txt
@@ -1,4 +1,4 @@
 {% load i18n widget_tweaks babybuddy qr_code %}
 {% url 'babybuddy:root-router' as relative_root_url %}
 {% make_absolute_url relative_root_url as absolute_root_url %}
-BABYBUDDY-LOGIN:{"url":"{{ absolute_root_url }}","api_key":"{{ user.settings.api_key }}"}
+BABYBUDDY-LOGIN:{"url":"{{ absolute_root_url }}","api_key":"{{ user.settings.api_key }}","session-cookie":"{{ session_cookie }}"}

--- a/babybuddy/tests/tests_home_assistant.py
+++ b/babybuddy/tests/tests_home_assistant.py
@@ -67,4 +67,6 @@ class HomeAssistantMiddlewareTestCase(TestCase):
         )
         json_response = json.loads(response.content)
 
-        self.assertEqual(json_response["profile"], "http://testserver/magic/sub/url/api/profile")
+        self.assertEqual(
+            json_response["profile"], "http://testserver/magic/sub/url/api/profile"
+        )

--- a/babybuddy/tests/tests_home_assistant.py
+++ b/babybuddy/tests/tests_home_assistant.py
@@ -1,0 +1,70 @@
+import json
+
+from django.test import TestCase, override_settings, tag
+from django.test import Client as HttpClient
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.core.management import call_command
+
+from faker import Faker
+
+from babybuddy.views import UserUnlock
+
+
+class HomeAssistantMiddlewareTestCase(TestCase):
+    """
+    Tests are executed on the REST-API because that one constructs
+    full absolute URLs. However, the middleware is part of the babybuddy
+    so the test lives in here.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(HomeAssistantMiddlewareTestCase, cls).setUpClass()
+        fake = Faker()
+        call_command("migrate", verbosity=0)
+
+        cls.c = HttpClient()
+
+        fake_user = fake.simple_profile()
+        cls.credentials = {
+            "username": fake_user["username"],
+            "password": fake.password(),
+        }
+        cls.user = get_user_model().objects.create_user(
+            is_superuser=True, is_staff=True, **cls.credentials
+        )
+
+    def test_no_ingress_request(self):
+        self.c.login(**self.credentials)
+
+        response = self.c.get("/api/", headers={"Accept": "application/json"})
+        json_response = json.loads(response.content)
+
+        self.assertEqual(json_response["profile"], "http://testserver/api/profile")
+
+    def test_ingress_request_no_x_ingress_path(self):
+        self.c.login(**self.credentials)
+
+        response = self.c.get(
+            "/api/",
+            headers={"Accept": "application/json", "X-Hass-Source": "core.ingress"},
+        )
+        json_response = json.loads(response.content)
+
+        self.assertEqual(json_response["profile"], "http://testserver/api/profile")
+
+    def test_ingress_request_with_x_ingress_path(self):
+        self.c.login(**self.credentials)
+
+        response = self.c.get(
+            "/api/",
+            headers={
+                "Accept": "application/json",
+                "X-Hass-Source": "core.ingress",
+                "X-Ingress-Path": "/magic/sub/url",
+            },
+        )
+        json_response = json.loads(response.content)
+
+        self.assertEqual(json_response["profile"], "http://testserver/magic/sub/url/api/profile")

--- a/babybuddy/views.py
+++ b/babybuddy/views.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth import update_session_auth_hash
@@ -251,15 +253,17 @@ class UserAddDevice(LoginRequiredMixin, View):
     qr_code_template = "babybuddy/login_qr_code.txt"
 
     def get(self, request):
-        session_cookie = ""
+        session_cookies = {}
         if request.is_homeassistant_ingress_request:
-            session_cookie = request.headers.get("Cookie", "")
+            session_cookies["ingress_session"] = ( 
+                request.COOKIES.get("ingress_session")
+            )
 
         qr_code_response = render(
             request,
             self.qr_code_template,
             {
-                "session_cookie": session_cookie,
+                "session_cookies": json.dumps(session_cookies)
             }
 
         )

--- a/babybuddy/views.py
+++ b/babybuddy/views.py
@@ -255,17 +255,12 @@ class UserAddDevice(LoginRequiredMixin, View):
     def get(self, request):
         session_cookies = {}
         if request.is_homeassistant_ingress_request:
-            session_cookies["ingress_session"] = ( 
-                request.COOKIES.get("ingress_session")
-            )
+            session_cookies["ingress_session"] = request.COOKIES.get("ingress_session")
 
         qr_code_response = render(
             request,
             self.qr_code_template,
-            {
-                "session_cookies": json.dumps(session_cookies)
-            }
-
+            {"session_cookies": json.dumps(session_cookies)},
         )
         qr_code_data = qr_code_response.content.decode().strip()
 

--- a/babybuddy/views.py
+++ b/babybuddy/views.py
@@ -251,7 +251,18 @@ class UserAddDevice(LoginRequiredMixin, View):
     qr_code_template = "babybuddy/login_qr_code.txt"
 
     def get(self, request):
-        qr_code_response = render(request, self.qr_code_template)
+        session_cookie = ""
+        if request.is_homeassistant_ingress_request:
+            session_cookie = request.headers.get("Cookie", "")
+
+        qr_code_response = render(
+            request,
+            self.qr_code_template,
+            {
+                "session_cookie": session_cookie,
+            }
+
+        )
         qr_code_data = qr_code_response.content.decode().strip()
 
         return render(

--- a/babybuddy/views.py
+++ b/babybuddy/views.py
@@ -253,6 +253,9 @@ class UserAddDevice(LoginRequiredMixin, View):
     qr_code_template = "babybuddy/login_qr_code.txt"
 
     def get(self, request):
+        # Assemble qr_code json-data. For Home Assistant ingress support, we
+        # also need to extract the ingress_session token to allow an external
+        # app to authenticate with home assistant so it can reach baby buddy
         session_cookies = {}
         if request.is_homeassistant_ingress_request:
             session_cookies["ingress_session"] = request.COOKIES.get("ingress_session")
@@ -264,6 +267,9 @@ class UserAddDevice(LoginRequiredMixin, View):
         )
         qr_code_data = qr_code_response.content.decode().strip()
 
+        # Now that the qr_code json-data is assembled, we can pass the json
+        # structure as data to the user_add_device - template where it will
+        # be converted into a qr-code.
         return render(
             request,
             self.template_name,

--- a/docs/configuration/homeassistant.md
+++ b/docs/configuration/homeassistant.md
@@ -1,0 +1,17 @@
+# Home Assistant
+
+## `HOME_ASSISTANT_USE_X_INGRESS_PATH`
+
+*Default:* `False`
+
+This setting should be set to `True` if babybuddy is hosted through the [ingress
+service of home assistant](https://developers.home-assistant.io/docs/add-ons/presentation/#ingress).
+
+This setting is necessary so that babybuddy can build correct absolute paths to
+itself when run in home assistant. The ingress routing of home assistant
+otherwise will obfuscate the true host-url and some functions, like the QR-code
+generator for coupling devices might not work correctly.
+
+**Do not enable this feature on other setups.** Attackers might be able to
+use this feature to redirect traffic in unexpected ways by manually adding
+`X-Ingress-Path` to the request URL.

--- a/docs/configuration/homeassistant.md
+++ b/docs/configuration/homeassistant.md
@@ -1,6 +1,6 @@
 # Home Assistant
 
-## `HOME_ASSISTANT_USE_X_INGRESS_PATH`
+## `ENABLE_HOME_ASSISTANT_SUPPORT`
 
 *Default:* `False`
 
@@ -12,6 +12,13 @@ itself when run in home assistant. The ingress routing of home assistant
 otherwise will obfuscate the true host-url and some functions, like the QR-code
 generator for coupling devices might not work correctly.
 
+In addition, the QR-Code that allows connecting external applications
+to baby buddy will expose home assistant's ingress-service cookie
+`ingress_session`. This cookie is created for a user visiting baby buddy through
+home assistant. It allows a connecting application to authenticate with
+home assistant's ingress service, which is a required extra step in
+for this setup.
+
 **Do not enable this feature on other setups.** Attackers might be able to
 use this feature to redirect traffic in unexpected ways by manually adding
-`X-Ingress-Path` to the request URL.
+`X-Ingress-Path` to the request headers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,9 +17,9 @@ nav:
     - 'configuration/application.md'
     - 'configuration/database.md'
     - 'configuration/email.md'
+    - 'configuration/homeassistant.md'
     - 'configuration/security.md'
     - 'configuration/storage.md'
-    - 'configuration/homeassistant.md'
   - 'User Guide':
     - 'user-guide/getting-started.md'
     - 'user-guide/managing-users.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
     - 'configuration/email.md'
     - 'configuration/security.md'
     - 'configuration/storage.md'
+    - 'configuration/homeassistant.md'
   - 'User Guide':
     - 'user-guide/getting-started.md'
     - 'user-guide/managing-users.md'


### PR DESCRIPTION
Relates to https://github.com/OttPeterR/addon-babybuddy/issues/47

## Changes

- Add a middleware that exposes the X-Ingress-Path via the Django-Http request object for later use
- Added settings-option to allow the middleware to use the X-Ingress-Path value to construct abolsute paths
    - This fixes a bunch of things in home assistant, for example, that paths generated by django rest framework are correct now! :partying_face: 
    - This fixes the absolute login path generated for and encoded in the QR-code when everything is run through home assistant
- The option to use X-Ingress-Path defaults to "OFF", added a special homeassistant config that enables the option
- In addition, the qr-code generating code searches and exposes the ìngress_session`cookie created and exposed by homeassistant. This allows the android app to use the same session to login to babybuddy hosted via the ingress-service of home assistant. _I am not quite sure if this is the correct way of doing this, I will try it out myself a bit to see if this works or not._