### PR TITLE
[Feature] Add Filter timers by name

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -99,7 +99,7 @@ class TemperatureFilter(TimeFieldFilter, TagsFieldFilter):
 class TimerFilter(StartEndFieldFilter):
     class Meta(StartEndFieldFilter.Meta):
         model = models.Timer
-        fields = sorted(StartEndFieldFilter.Meta.fields + ["user"])
+        fields = sorted(StartEndFieldFilter.Meta.fields + ["name", "user"])
 
 
 class TummyTimeFilter(StartEndFieldFilter, TagsFieldFilter):


### PR DESCRIPTION
This commit introduces a new feature that allows users to filter timers by their names. With this enhancement, users can now easily locate timers even if they don't know their exact IDs or are unaware of the existence of certain timers. This improvement facilitates seamless integration with programming scenarios like Apple Shortcuts, enabling more elegant solutions. 
