### PR TITLE
Feat: Increase mobile friendliness of forms

### DIFF
--- a/babybuddy/static_src/js/babybuddy.js
+++ b/babybuddy/static_src/js/babybuddy.js
@@ -43,3 +43,19 @@ $("form").off("submit", preventDoubleSubmit);
 $("form").on("submit", function () {
   $(this).on("submit", preventDoubleSubmit);
 });
+
+BabyBuddy.RememberAdvancedToggle = function (ptr) {
+  localStorage.setItem("advancedForm", event.newState);
+};
+
+(function toggleAdvancedFields() {
+  window.addEventListener("load", function () {
+    if (localStorage.getItem("advancedForm") !== "open") {
+      return;
+    }
+
+    document.querySelectorAll(".advanced-fields").forEach(function (node) {
+      node.open = true;
+    });
+  });
+})();

--- a/babybuddy/static_src/scss/forms.scss
+++ b/babybuddy/static_src/scss/forms.scss
@@ -52,3 +52,9 @@
         position: relative;
     }
 }
+
+form .row details {
+    // removing this causes slight mis-alignment between fields in the details and the rest of the fields 
+    //on the form at the left hand side of the box
+    padding-right: 0;
+}

--- a/babybuddy/static_src/scss/forms.scss
+++ b/babybuddy/static_src/scss/forms.scss
@@ -33,6 +33,20 @@
     z-index: 1030;
 }
 
+.pill-container {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 10px;
+    row-gap: 10px;
+}
+
+// Only grow pill buttons on when using a mobile
+@include media-breakpoint-down(sm) {
+    .pill-container>label {
+            flex-grow: 1;
+        }
+}
+
 // Tweak padding on form field help blocks.
 .help-block {
     ul {

--- a/babybuddy/static_src/scss/forms.scss
+++ b/babybuddy/static_src/scss/forms.scss
@@ -53,7 +53,17 @@
     }
 }
 
-form .row details {
+@include media-breakpoint-down(md) {
+    .advanced-fields__summary {
+        text-align: center;
+    }
+}
+
+.advanced-fields__summary > * {
+    display: inline
+}
+
+.advanced-fields {
     // removing this causes slight mis-alignment between fields in the details and the rest of the fields 
     //on the form at the left hand side of the box
     padding-right: 0;

--- a/babybuddy/templates/babybuddy/base.html
+++ b/babybuddy/templates/babybuddy/base.html
@@ -44,22 +44,6 @@
         <script src="{% static "babybuddy/js/vendor.js" %}"></script>
         <script src="{% static "babybuddy/js/app.js" %}"></script>
         {% if user.is_authenticated %}<script>BabyBuddy.PullToRefresh.init()</script>{% endif %}
-        {% block javascript %}
-            <script type="application/javascript">
-                function rememberAdvancedToggle(event, element){
-                    localStorage.setItem("advancedForm",event.newState)
-                }
-
-                window.addEventListener('load', function () {
-                    if(localStorage.getItem("advancedForm") !== "open"){
-                        return;
-                    }
-
-                    document.querySelectorAll("form details").forEach(function(node){
-                        node.open = true
-                    });
-                })
-            </script>
-        {% endblock %}
+        {% block javascript %}{% endblock %}
     </body>
 </html>

--- a/babybuddy/templates/babybuddy/base.html
+++ b/babybuddy/templates/babybuddy/base.html
@@ -44,6 +44,22 @@
         <script src="{% static "babybuddy/js/vendor.js" %}"></script>
         <script src="{% static "babybuddy/js/app.js" %}"></script>
         {% if user.is_authenticated %}<script>BabyBuddy.PullToRefresh.init()</script>{% endif %}
-        {% block javascript %}{% endblock %}
+        {% block javascript %}
+            <script type="application/javascript">
+                function rememberAdvancedToggle(event, element){
+                    localStorage.setItem("advancedForm",event.newState)
+                }
+
+                window.addEventListener('load', function () {
+                    if(localStorage.getItem("advancedForm") !== "open"){
+                        return;
+                    }
+
+                    document.querySelectorAll("form details").forEach(function(node){
+                        node.open = true
+                    });
+                })
+            </script>
+        {% endblock %}
     </body>
 </html>

--- a/babybuddy/templates/babybuddy/form.html
+++ b/babybuddy/templates/babybuddy/form.html
@@ -4,10 +4,18 @@
 <div class="container-fluid pb-5">
     <form role="form" method="post" enctype="multipart/form-data">
         {% csrf_token %}
-        {% for field in form %}
-            {{ field.widget }}
-            <div class="row">{% include 'babybuddy/form_field.html' %}</div>
-        {% endfor %}
+        {% if form.fieldsets %}
+            {% for fieldset in form.hydrated_fielsets %}
+                {% with "forms/layouts/"|add:fieldset.layout|add:".html" as template %}
+                    {% include template %}
+                {% endwith %}
+            {% endfor %}
+        {% else %}
+            {% for field in form %}
+                {{ field.widget }}
+                <div class="row">{% include 'babybuddy/form_field.html' %}</div>
+            {% endfor %}
+        {% endif %}
         <button type="submit" class="submit-primary btn btn-primary btn-lg">{% trans "Submit" %}</button>
     </form>
 </div>

--- a/babybuddy/templates/babybuddy/form_field.html
+++ b/babybuddy/templates/babybuddy/form_field.html
@@ -5,35 +5,6 @@
         {{ field.label }}
     </label>
     <div class="col-sm-10{% if field|widget_type == 'childradioselect' %} overflow-auto"{% endif %}">
-        {% if field|field_type == "booleanfield" %}
-            {% if field.errors %}
-                {{ field|add_class:"btn-check is-invalid" }}
-            {% else %}
-                {{ field|add_class:"btn-check" }}
-            {% endif %}
-            <label for="id_{{ field.name }}" class="btn btn-outline-light btn-no-hover">{{ field.label }}</label>
-        {% elif 'choice' in field|field_type %}
-            {% if field.errors %}
-                {{ field|add_class:"form-select is-invalid" }}
-            {% else %}
-                {{ field|add_class:"form-select" }}
-            {% endif %}
-        {% else %}
-            {% if field.errors %}
-                {{ field|add_class:"form-control is-invalid" }}
-            {% else %}
-                {{ field|add_class:"form-control" }}
-            {% endif %}
-        {% endif %}
-        {% if field.help_text %}
-            <div class="help-block">
-                <small>{{ field.help_text }}</small>
-            </div>
-        {% endif %}
-        {% if field.errors %}
-            <div class="invalid-feedback">
-                {% for error in  field.errors %}{{ error }}{% endfor %}
-            </div>
-        {% endif %}
+        {% include 'babybuddy/form_field_no_label.html' %}
     </div>
 </div>

--- a/babybuddy/templates/babybuddy/form_field_no_label.html
+++ b/babybuddy/templates/babybuddy/form_field_no_label.html
@@ -1,0 +1,31 @@
+{% load widget_tweaks %}
+{% if field|field_type == "booleanfield" %}
+    {% if field.errors %}
+        {{ field|add_class:"btn-check is-invalid" }}
+    {% else %}
+        {{ field|add_class:"btn-check" }}
+    {% endif %}
+    <label for="id_{{ field.name }}" class="btn btn-outline-light btn-no-hover">{{ field.label }}</label>
+{% elif 'choice' in field|field_type %}
+    {% if field.errors %}
+        {{ field|add_class:"form-select is-invalid" }}
+    {% else %}
+        {{ field|add_class:"form-select" }}
+    {% endif %}
+{% else %}
+    {% if field.errors %}
+        {{ field|add_class:"form-control is-invalid" }}
+    {% else %}
+        {{ field|add_class:"form-control" }}
+    {% endif %}
+{% endif %}
+{% if field.help_text %}
+    <div class="help-block">
+        <small>{{ field.help_text }}</small>
+    </div>
+{% endif %}
+{% if field.errors %}
+    <div class="invalid-feedback">
+        {% for error in  field.errors %}{{ error }}{% endfor %}
+    </div>
+{% endif %}

--- a/core/forms.py
+++ b/core/forms.py
@@ -277,6 +277,14 @@ class NoteForm(CoreModelForm, TaggableModelForm):
 
 
 class SleepForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "start", "end", "nap"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.Sleep
         fields = ["child", "start", "end", "nap", "notes", "tags"]
@@ -289,6 +297,14 @@ class SleepForm(CoreModelForm, TaggableModelForm):
 
 
 class TemperatureForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "temperature", "time"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.Temperature
         fields = ["child", "temperature", "time", "notes", "tags"]
@@ -320,6 +336,14 @@ class TimerForm(CoreModelForm):
 
 
 class TummyTimeForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "start", "end", "milestone"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["tags"]},
+    ]
+
     class Meta:
         model = models.TummyTime
         fields = ["child", "start", "end", "milestone", "tags"]
@@ -331,6 +355,14 @@ class TummyTimeForm(CoreModelForm, TaggableModelForm):
 
 
 class WeightForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "weight", "date"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.Weight
         fields = ["child", "weight", "date", "notes", "tags"]
@@ -342,6 +374,14 @@ class WeightForm(CoreModelForm, TaggableModelForm):
 
 
 class HeightForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "height", "date"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.Height
         fields = ["child", "height", "date", "notes", "tags"]
@@ -353,6 +393,14 @@ class HeightForm(CoreModelForm, TaggableModelForm):
 
 
 class HeadCircumferenceForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "head_circumference", "date"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.HeadCircumference
         fields = ["child", "head_circumference", "date", "notes", "tags"]
@@ -364,6 +412,14 @@ class HeadCircumferenceForm(CoreModelForm, TaggableModelForm):
 
 
 class BMIForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "bmi", "date"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.BMI
         fields = ["child", "bmi", "date", "notes", "tags"]

--- a/core/forms.py
+++ b/core/forms.py
@@ -10,7 +10,7 @@ from taggit.forms import TagField
 from babybuddy.widgets import DateInput, DateTimeInput, TimeInput
 from core import models
 from core.models import Timer
-from core.widgets import TagsEditor, ChildRadioSelect
+from core.widgets import TagsEditor, ChildRadioSelect, PillRadioSelect
 
 
 def set_initial_values(kwargs, form_type):
@@ -201,6 +201,7 @@ class BottleFeedingForm(CoreModelForm, TaggableModelForm):
         widgets = {
             "child": ChildRadioSelect,
             "start": DateTimeInput(),
+            "type": PillRadioSelect(),
             "notes": forms.Textarea(attrs={"rows": 5}),
         }
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -216,6 +216,14 @@ class DiaperChangeForm(CoreModelForm, TaggableModelForm):
 
 
 class FeedingForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "start", "end", "type", "method", "amount"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.Feeding
         fields = ["child", "start", "end", "type", "method", "amount", "notes", "tags"]
@@ -223,6 +231,8 @@ class FeedingForm(CoreModelForm, TaggableModelForm):
             "child": ChildRadioSelect,
             "start": DateTimeInput(),
             "end": DateTimeInput(),
+            "type": PillRadioSelect(),
+            "method": PillRadioSelect(),
             "notes": forms.Textarea(attrs={"rows": 5}),
         }
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -107,6 +107,31 @@ class CoreModelForm(forms.ModelForm):
             self.save_m2m()
         return instance
 
+    @property
+    def hydrated_fielsets(self):
+        # for some reason self.fields returns defintions and not bound fields
+        # so until i figure out a better way we can just create a dict here
+        # https://github.com/django/django/blob/main/django/forms/forms.py#L52
+
+        bound_field_dict = {}
+        for field in self:
+            bound_field_dict[field.name] = field
+
+        hydrated_fieldsets = []
+
+        for fieldset in self.fieldsets:
+            hyrdrated_fieldset = {
+                "layout": fieldset["layout"],
+                "layout_attrs": fieldset.get("layout_attrs", {}),
+                "fields": [],
+            }
+            for field_name in fieldset["fields"]:
+                hyrdrated_fieldset["fields"].append(bound_field_dict[field_name])
+
+            hydrated_fieldsets.append(hyrdrated_fieldset)
+
+        return hydrated_fieldsets
+
 
 class ChildForm(forms.ModelForm):
     class Meta:

--- a/core/forms.py
+++ b/core/forms.py
@@ -178,6 +178,11 @@ class TaggableModelForm(forms.ModelForm):
 
 
 class PumpingForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {"fields": ["child", "start", "end", "amount"], "layout": "required"},
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.Pumping
         fields = ["child", "start", "end", "amount", "notes", "tags"]
@@ -190,6 +195,16 @@ class PumpingForm(CoreModelForm, TaggableModelForm):
 
 
 class DiaperChangeForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["wet", "solid"],
+            "layout": "choices",
+            "layout_attrs": {"label": "Contents"},
+        },
+        {"fields": ["child", "time"], "layout": "required"},
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     class Meta:
         model = models.DiaperChange
         fields = ["child", "time", "wet", "solid", "color", "amount", "notes", "tags"]
@@ -213,6 +228,14 @@ class FeedingForm(CoreModelForm, TaggableModelForm):
 
 
 class BottleFeedingForm(CoreModelForm, TaggableModelForm):
+    fieldsets = [
+        {
+            "fields": ["child", "type", "start", "amount"],
+            "layout": "required",
+        },
+        {"layout": "advanced", "fields": ["notes", "tags"]},
+    ]
+
     def save(self):
         instance = super(BottleFeedingForm, self).save(commit=False)
         instance.method = "bottle"

--- a/core/templates/core/pill_radio.html
+++ b/core/templates/core/pill_radio.html
@@ -1,5 +1,5 @@
 {% with id=widget.attrs.id %}
-    <div {% if id %}id="{{ id }}"{% endif %} class="radio-container">
+    <div {% if id %}id="{{ id }}"{% endif %} class="pill-container">
         {% for group, options, index in widget.optgroups %}
             {% for option in options %}
                 {% if option.value != '' %}

--- a/core/templates/core/pill_radio.html
+++ b/core/templates/core/pill_radio.html
@@ -1,0 +1,11 @@
+{% with id=widget.attrs.id %}
+    <div {% if id %}id="{{ id }}"{% endif %} class="radio-container">
+        {% for group, options, index in widget.optgroups %}
+            {% for option in options %}
+                {% if option.value != '' %}
+                    {% include option.template_name with widget=option %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    </div>
+{% endwith %}

--- a/core/templates/core/pill_radio_option.html
+++ b/core/templates/core/pill_radio_option.html
@@ -1,0 +1,3 @@
+{% include "django/forms/widgets/input.html" %}
+<label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}
+       class="btn btn-outline-light btn-no-hover">{{ widget.label }}</label>

--- a/core/templates/forms/layouts/advanced.html
+++ b/core/templates/forms/layouts/advanced.html
@@ -1,0 +1,10 @@
+<div class="row">
+    <div class="row mb-3">
+        <details ontoggle="rememberAdvancedToggle(event)">
+            <summary>Advanced</summary>
+            {% for field in fieldset.fields %}
+                <div class="row">{% include "babybuddy/form_field.html" %}</div>
+            {% endfor %}
+        </details>
+    </div>
+</div>

--- a/core/templates/forms/layouts/advanced.html
+++ b/core/templates/forms/layouts/advanced.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 <div class="row">
     <div class="row mb-3">
-        <details ontoggle="rememberAdvancedToggle(event)" class="advanced-fields">
+        <details ontoggle="BabyBuddy.RememberAdvancedToggle(event)"
+                 class="advanced-fields">
             <summary class="advanced-fields__summary">
                 <h4>{% trans "Advanced Fields" %}</h4>
             </summary>

--- a/core/templates/forms/layouts/advanced.html
+++ b/core/templates/forms/layouts/advanced.html
@@ -1,7 +1,10 @@
+{% load i18n %}
 <div class="row">
     <div class="row mb-3">
-        <details ontoggle="rememberAdvancedToggle(event)">
-            <summary>Advanced</summary>
+        <details ontoggle="rememberAdvancedToggle(event)" class="advanced-fields">
+            <summary class="advanced-fields__summary">
+                <h4>{% trans "Advanced Fields" %}</h4>
+            </summary>
             {% for field in fieldset.fields %}
                 <div class="row">{% include "babybuddy/form_field.html" %}</div>
             {% endfor %}

--- a/core/templates/forms/layouts/choices.html
+++ b/core/templates/forms/layouts/choices.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+<div class="row mb-3">
+    <label for="id_child" class="col-sm-2 col-form-label">{% trans fieldset.layout_attrs.label %}</label>
+    <div class="col-sm-10 overflow-auto">
+        {% for field in fieldset.fields %}
+            {% include "babybuddy/form_field_no_label.html" %}
+        {% endfor %}
+    </div>
+</div>

--- a/core/templates/forms/layouts/choices.html
+++ b/core/templates/forms/layouts/choices.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="row mb-3">
     <label for="id_child" class="col-sm-2 col-form-label">{% trans fieldset.layout_attrs.label %}</label>
-    <div class="col-sm-10 overflow-auto">
+    <div class="col-sm-10 overflow-auto pill-container">
         {% for field in fieldset.fields %}
             {% include "babybuddy/form_field_no_label.html" %}
         {% endfor %}

--- a/core/templates/forms/layouts/required.html
+++ b/core/templates/forms/layouts/required.html
@@ -1,0 +1,3 @@
+{% for field in fieldset.fields %}
+    <div class="row">{% include "babybuddy/form_field.html" %}</div>
+{% endfor %}

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -104,3 +104,16 @@ class ChildRadioSelect(RadioSelect):
         if value != "":
             option["picture"] = value.instance.picture
         return option
+
+
+class PillRadioSelect(RadioSelect):
+    input_type = "radio"
+    template_name = "core/pill_radio.html"
+    option_template_name = "core/pill_radio_option.html"
+
+    attrs = {"class": "btn-check"}
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["class"] += " btn-check"
+        return attrs


### PR DESCRIPTION
While experimenting on https://github.com/babybuddy/babybuddy/pull/754. I explored variations of form layout with fewer input boxes and replaced drop downs for pills to reduce clicks on mobile.

What I don't want to do is create an entirely forked UI, so this PR attempted to add the elements but using the original skin.

I added the advanced option, as I believe that people will use tags and notes because there is something they cannot represent in the core data model, so ideally, it is not a core feature that people use. For that reason, it defaults to hidden until people use it. Then, it will use the last toggle state.

My implementation of the fieldset might not be ideal; I just did it so that I knew how to do it in Django (hardly code in Python/Django), so feel free to modify or let me know how you want it done.

Adding the toggle code for the details, as I did, is probably not ideal. I'm happy to change.

We could bring back the drop-downs on the desktop if we wanted to by rendering both and using a media query.

### Screenshots
<img height="277" alt="image" src="https://github.com/babybuddy/babybuddy/assets/1640136/a2d3c70e-5ce8-46da-b5ea-0b4cbd42cff3">
<img height="277" alt="image" src="https://github.com/babybuddy/babybuddy/assets/1640136/d294ef2b-efa8-4031-8be7-1bd5beb19e8f">
<img height="277" alt="image" src="https://github.com/babybuddy/babybuddy/assets/1640136/d376d82e-cfe4-4ee0-8d8f-8969067452c9">
<img width="1792" alt="image" src="https://github.com/babybuddy/babybuddy/assets/1640136/b706760e-b509-4761-85f3-65876cd97ccb">
<img width="1788" alt="image" src="https://github.com/babybuddy/babybuddy/assets/1640136/a8473860-9b8a-4be3-abc9-0f1433e3d2ec">
<img width="1049" alt="image" src="https://github.com/babybuddy/babybuddy/assets/1640136/63aee8a1-ad4a-4d28-841d-31db1ce0bbb9">




