### PR TITLE
Add external developer documentation to BBoTW README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ adding it here or reach out via GitHub Issues or Discussions or on Gitter!
   - [part 1](https://lutzky.net/2021/10/03/software-parenting-1/)
   - [part 2](https://lutzky.net/2021/10/05/software-parenting-2/)
   - [part 3](https://lutzky.net/2021/10/10/software-parenting-3/)
+- [High Level Developer Documentation (AI-Generated)](https://wiki.mutable.ai/babybuddy/babybuddy)
 
 ## Reporting Vulnerabilities
 


### PR DESCRIPTION
relates to https://github.com/orgs/babybuddy/discussions/773

