### PR TITLE
Remove duplicate amount field in bottle field

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -166,7 +166,6 @@ class BMIForm(CoreModelForm, TaggableModelForm):
 class BottleFeedingForm(CoreModelForm, TaggableModelForm):
     fieldsets = [
         {"fields": ["child", "type", "start", "amount"], "layout": "required"},
-        {"fields": ["amount"]},
         {"fields": ["notes", "tags"], "layout": "advanced"},
     ]
 


### PR DESCRIPTION
v2.3.1 introduced a second amount field for bottle feeds. This PR removes the second, non-required field.

Refs #800