### PR TITLE
Fix layout of diaper change form buttons on mobile

### DIFF
--- a/core/templates/forms/layouts/choices.html
+++ b/core/templates/forms/layouts/choices.html
@@ -1,9 +1,11 @@
 {% load i18n %}
-<div class="row mb-3">
-    <label for="id_child" class="col-sm-2 col-form-label">{% trans fieldset.layout_attrs.label %}</label>
-    <div class="col-sm-10 overflow-auto pill-container">
-        {% for field in fieldset.fields %}
-            {% include "babybuddy/form_field_no_label.html" %}
-        {% endfor %}
+<div class="row">
+    <div class="row mb-3">
+        <label for="id_child" class="col-sm-2 col-form-label">{% trans fieldset.layout_attrs.label %}</label>
+        <div class="col-sm-10 overflow-auto pill-container">
+            {% for field in fieldset.fields %}
+                {% include "babybuddy/form_field_no_label.html" %}
+            {% endfor %}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
A small fix for a layout issue I noticed since updating.

Before:
![babybuddy-before](https://github.com/babybuddy/babybuddy/assets/8278253/e1393710-0f26-43d8-b62b-4acb2142af18)


After (Mobile):
![babybuddy-after](https://github.com/babybuddy/babybuddy/assets/8278253/e2fb929c-e9ce-4000-92e0-d92218e97d5f)

After (Wide viewport):
![babybuddy-after-wide](https://github.com/babybuddy/babybuddy/assets/8278253/e2415b3e-d99b-4ce6-b3ef-2558da70dea2)
