### PR TITLE
Add suggestions to the tag editor widget

### DIFF
--- a/core/templates/core/widget_tag_editor.html
+++ b/core/templates/core/widget_tag_editor.html
@@ -22,7 +22,13 @@
             <input class="form-control"
                    type="text"
                    name=""
+                   list="tag-list"
                    placeholder="{% trans "Tag name" %}">
+            {% if widget.tag_suggestions.most %}
+                <datalist id="tag-list">
+                    {% for t in widget.tag_suggestions.most %}<option value="{{ t.name }}" />{% endfor %}
+                </datalist>
+            {% endif %}
             <button id="add-tag" class="btn btn-outline-primary bg" type="button">{% trans "Add" %}</button>
         </div>
         {% if widget.tag_suggestions.quick %}


### PR DESCRIPTION
**What**
Add suggestions when entering a tag in the tag editor widget. Suggestions are based on the 256 most recently used tags.

**How**
Uses the HTML standard element datalist which is supported by most major browsers, only firefox mobile lacks support [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist#browser_compatibility).
The suggestions are already loaded in the [`TagsEditor` class](https://github.com/babybuddy/babybuddy/blob/946f006e5a157b827eec7fb402bc2d3bab01dfa2/core/widgets.py#L67), so only the HTML is changed to display the suggestions.
Suggestion list is refined as characters are entered into the input field.
Tested on an instance with 10.000 tags, with no perceptible slowdown.


**Why**
When tagging an entry the quick suggestions are great, but if you need to use another tag you must write it manually. This poses a problem as the tags are case sensitive, to it is easy to end up with duplicate tags.

![image](https://github.com/babybuddy/babybuddy/assets/4235153/4480ea42-fd30-45a8-8acd-f35cae20ff9b)
Screenshot from firefox.