### PR TITLE
Add ability to configure CORS headers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ uritemplate = "*"
 whitenoise = "*"
 django-taggit = "*"
 django-qr-code = "*"
+django-cors-headers = "*"
 django-dbsettings = "*"
 django-import-export = "*"
 

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     "api",
     "babybuddy.apps.BabyBuddyConfig",
     "core.apps.CoreConfig",
+    "corsheaders",
     "dashboard",
     "reports",
     "axes",
@@ -64,6 +65,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "babybuddy.middleware.RollingSessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -323,6 +325,10 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
+
+# https://github.com/adamchainz/django-cors-headers
+if os.environ.get('CORS_ALLOWED_ORIGINS'):
+    CORS_ALLOWED_ORIGINS = [x.strip() for x in os.environ.get('CORS_ALLOWED_ORIGINS').split(',')]
 
 # Django Rest Framework
 # https://www.django-rest-framework.org/

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 load_dotenv(find_dotenv())
 
 # Required settings
-ALLOWED_HOSTS = [x.strip() for x in os.environ.get('ALLOWED_HOSTS', "*").split(',')]
+ALLOWED_HOSTS = [x.strip() for x in os.environ.get("ALLOWED_HOSTS", "*").split(",")]
 SECRET_KEY = os.environ.get("SECRET_KEY") or None
 DEBUG = bool(strtobool(os.environ.get("DEBUG") or "False"))
 
@@ -326,8 +326,10 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # https://github.com/adamchainz/django-cors-headers
-if os.environ.get('CORS_ALLOWED_ORIGINS'):
-    CORS_ALLOWED_ORIGINS = [x.strip() for x in os.environ.get('CORS_ALLOWED_ORIGINS').split(',')]
+if os.environ.get("CORS_ALLOWED_ORIGINS"):
+    CORS_ALLOWED_ORIGINS = [
+        x.strip() for x in os.environ.get("CORS_ALLOWED_ORIGINS").split(",")
+    ]
 
 # Django Rest Framework
 # https://www.django-rest-framework.org/

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -24,8 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 load_dotenv(find_dotenv())
 
 # Required settings
-
-ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
+ALLOWED_HOSTS = [x.strip() for x in os.environ.get('ALLOWED_HOSTS', "*").split(',')]
 SECRET_KEY = os.environ.get("SECRET_KEY") or None
 DEBUG = bool(strtobool(os.environ.get("DEBUG") or "False"))
 

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -4,14 +4,14 @@
 
 _Default:_ `*` (any host)
 
-Set this variable to a single host or comma-separated list of hosts without spaces.
+Set this variable to a single host or comma-separated list of hosts.
 This should _always_ be set to a specific host or hosts in production deployments.
 
 Do not include schemes ("http" or "https") with this setting.
 
 **Example value**
 
-    baby.example.test,baby.example2.test
+    baby.example.test, baby.example2.test
 
 **See also**
 

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -19,6 +19,24 @@ Do not include schemes ("http" or "https") with this setting.
 - [`CSRF_TRUSTED_ORIGINS`](#csrf_trusted_origins)
 - [`SECURE_PROXY_SSL_HEADER`](#secure_proxy_ssl_header)
 
+## `CORS_ALLOWED_ORIGINS`
+
+_Default:_ `""` (no cross-origin requests allowed)
+
+Set this variable to a single origin or comma-separated list of origins. Include schemes
+("http" or "https") and any non-default ports in each origin.
+
+This allows cross-origin requests to the API from the specified origins.
+
+**Example value**
+
+    https://other-domain.example.com, http://localhost:8888
+
+**See also**
+
+- [MDN article on CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+- [Making cross origin requests using fetch()](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#making_cross-origin_requests)
+
 ## `CSRF_COOKIE_SECURE`
 
 _Default:_ `False`

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ dj-database-url==2.2.0
 django==5.0.6; python_version >= '3.10'
 django-appconf==1.0.6; python_version >= '3.7'
 django-axes==6.5.0; python_version >= '3.7'
+django-cors-headers==4.4.0; python_version >= '3.8'
 django-dbsettings==1.3.0
 django-filter==24.2; python_version >= '3.8'
 django-imagekit==5.0.0


### PR DESCRIPTION
Fixes #842 

I *think* I did the installation of `django-cors-headers` correctly, but I'm not too familiar with Python environment setup and was having a bit of trouble installing dependencies. Make sure my change to `requirements.txt` is correct and that I don't need to make any other changes elsewhere.

### Changes
* Install `django-cors-headers`
* Read comma separated list of origins from `CORS_ALLOWED_ORIGINS` env var, and pass as list to `django-cors-headers`
  * `.strip()` to remove whitespace from each item, allowing spaces in the comma separated list
  * Add `.strip()` to `ALLOWED_HOSTS` value for convenience
* Add/update documentation

Let me know if there are any tests I should add. Though if you feel like writing them yourself feel free - not sure how long it'll take me to figure out the Python test environment.