### PR TITLE
Fix minor UI bug with feeding pattern report

### DIFF
--- a/reports/graphs/feeding_pattern.py
+++ b/reports/graphs/feeding_pattern.py
@@ -66,6 +66,15 @@ def feeding_pattern(feedings):
 
         if last_end_time:
             if last_end_time.date() < start_time.date():
+                # Not feeding across midnight
+                last_date = last_end_time.date().isoformat()
+                last_midnight = last_end_time.replace(hour=23, minute=59)
+                days[last_date].append(
+                    {
+                        "time": (last_midnight - last_end_time).seconds / 60,
+                        "label": None,
+                    }
+                )
                 last_end_time = start_time.replace(hour=0, minute=0, second=0)
 
         if not last_end_time:


### PR DESCRIPTION
A browser on one of my devices outlines each entry of the report in white. That leaves an awkward area at the end of each day where there is no outline unless there happens to be a feeding across the midnight boundary. This adds a new entry from the end of the previous feeding to midnight in order to make the outline consistent.

Before: 
![before](https://github.com/user-attachments/assets/37422cb3-b06d-428e-81f5-06b217648ed1)

After:
![after](https://github.com/user-attachments/assets/b6f6468d-138c-4b59-b1f0-cb3485c0d6f7)
