### PR TITLE
docs: minor fixes to typos and deadlink

### DIFF
--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -15,7 +15,7 @@ information and steps below to set up a local development environment for Baby B
 
 ## Installation
 
-1. Install pipenv per [Installing pipenv](https://pipenv.pypa.io/en/latest/installation/)
+1. Install pipenv per [Pipenv installation](https://pipenv.pypa.io/en/latest/installation.html)
 
 1. Install required Python packages, including dev packages
 

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -17,7 +17,7 @@ information and steps below to set up a local development environment for Baby B
 
 1. Install pipenv per [Pipenv installation](https://pipenv.pypa.io/en/latest/installation.html)
 
-1. Install required Python packages, including dev packages
+2. Install required Python packages, including dev packages
 
    ```shell
    pipenv install --three --dev
@@ -25,31 +25,31 @@ information and steps below to set up a local development environment for Baby B
 
    If this fails, install `libpq-dev` (e.g. `sudo apt install libpq-dev`) and try again.
 
-1. Installed Node 18.x (if necessary)
+3. Installed Node 18.x (if necessary)
 
    ```shell
    nvm install 18
    ```
 
-1. Activate Node 18.x
+4. Activate Node 18.x
 
    ```shell
    nvm use
    ```
 
-1. Install Gulp CLI
+5. Install Gulp CLI
 
    ```shell
    npm install -g gulp-cli
    ```
 
-1. Install required Node packages
+6. Install required Node packages
 
    ```shell
    npm install
    ```
 
-1. Set, at least, the `DJANGO_SETTINGS_MODULE` environment variable
+7. Set, at least, the `DJANGO_SETTINGS_MODULE` environment variable
 
    ```shell
    export DJANGO_SETTINGS_MODULE=babybuddy.settings.development
@@ -59,13 +59,13 @@ information and steps below to set up a local development environment for Baby B
    Linux-based systems. See [Configuration](../configuration/intro.md) for other
    settings and methods for defining them.
 
-1. Migrate the database
+8. Migrate the database
 
    ```shell
    gulp migrate
    ```
 
-1. Build assets and run the server
+9. Build assets and run the server
 
    ```shell
    gulp

--- a/docs/setup/deployment.md
+++ b/docs/setup/deployment.md
@@ -94,7 +94,7 @@ Access and configuration instructions will be provided after the droplet has bee
 
 Use the button below to start a new deploy to [Digital Ocean](https://www.digitalocean.com/?refcode=dd79e4cfd7b6&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge).
 
-Modify the app enviornment variables during the build configuration and set the `SECRET_KEY` value to something random
+Modify the app environment variables during the build configuration and set the `SECRET_KEY` value to something random
 and unique. Digital Ocean's automatic secret generator does not work with Baby Buddy.
 
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/babybuddy/babybuddy/tree/master&refcode=dd79e4cfd7b6)
@@ -127,17 +127,17 @@ deployment URL of your Clever Cloud Python application.
 ## GCP Cloud Run
 
 Baby Buddy can be hosted serverless in GCP Cloud Run using configuration provided at
-`terraform/gcp-cloud-run`. The configuration scales down to zero for cost effectiveness.
+`terraform/gcp-cloud-run`. The configuration scales down to zero for cost-effectiveness.
 With this approach initial requests to the service after a long period will be slow but
 subsequent requests will be much faster.
 A [billing account](https://cloud.google.com/billing/docs/how-to/create-billing-account)
 mut be configured in GCP to use the configuration.
 
 The terraform code isn't production ready and is meant to be a good way of getting started.
-No state strage is configured. See [storage options](https://cloud.google.com/run/docs/storage-options)
-for information about how to configure persistant storage.
+No state storage is configured. See [storage options](https://cloud.google.com/run/docs/storage-options)
+for information about how to configure persistent storage.
 
-Run `terraform init` from the configurtion directory to get started:
+Run `terraform init` from the configuration directory to get started:
 
 ```shell
 git clone https://github.com/babybuddy/babybuddy.git

--- a/docs/setup/deployment.md
+++ b/docs/setup/deployment.md
@@ -58,10 +58,12 @@ that can be used to host and control Baby Buddy. An existing Home Assistant inst
 is required to use this method.
 
 See the community-maintained [Baby Buddy Home Assistant Addon](https://github.com/OttPeterR/addon-babybuddy)
-for installation instructions and then review the community-maintained [Baby Buddy Home Assistant integration](https://github.com/jcgoette/baby_buddy_homeassistant)
+for installation instructions and then review the
+community-maintained [Baby Buddy Home Assistant integration](https://github.com/jcgoette/baby_buddy_homeassistant)
 for added integrations with the base Home Assistant system.
 
-See also [How to Setup Baby Buddy in Home Assistant](https://smarthomescene.com/guides/how-to-setup-baby-buddy-in-home-assistant/)
+See
+also [How to Setup Baby Buddy in Home Assistant](https://smarthomescene.com/guides/how-to-setup-baby-buddy-in-home-assistant/)
 from Smart Home Scene for more detailed installation and configuration instructions.
 
 ## Digital Ocean
@@ -92,7 +94,8 @@ Access and configuration instructions will be provided after the droplet has bee
 
 Use the button below to start a new deploy to [Digital Ocean](https://www.digitalocean.com/?refcode=dd79e4cfd7b6&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge).
 
-Modify the app enviornment variables during the build configuration and set the `SECRET_KEY` value to something random and unique. Digital Ocean's automatic secret generator does not work with Baby Buddy.
+Modify the app enviornment variables during the build configuration and set the `SECRET_KEY` value to something random
+and unique. Digital Ocean's automatic secret generator does not work with Baby Buddy.
 
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/babybuddy/babybuddy/tree/master&refcode=dd79e4cfd7b6)
 
@@ -126,7 +129,8 @@ deployment URL of your Clever Cloud Python application.
 Baby Buddy can be hosted serverless in GCP Cloud Run using configuration provided at
 `terraform/gcp-cloud-run`. The configuration scales down to zero for cost effectiveness.
 With this approach initial requests to the service after a long period will be slow but
-subsequent requests will be much faster. A [billing account](https://cloud.google.com/billing/docs/how-to/create-billing-account)
+subsequent requests will be much faster.
+A [billing account](https://cloud.google.com/billing/docs/how-to/create-billing-account)
 mut be configured in GCP to use the configuration.
 
 The terraform code isn't production ready and is meant to be a good way of getting started.


### PR DESCRIPTION
Small improvements to documentations as I went through them:
1. Fix typos
2. Fix dead link
3. Format with line breaks (for IDEs)
4. Fix numbering