### PR TITLE
feat(SMTP): allow to specify sender name

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -286,7 +286,7 @@ if os.environ.get("EMAIL_HOST"):
     EMAIL_USE_SSL = bool(strtobool(os.environ.get("EMAIL_USE_SSL") or "False"))
     EMAIL_SSL_KEYFILE = os.environ.get("EMAIL_SSL_KEYFILE") or None
     EMAIL_SSL_CERTFILE = os.environ.get("EMAIL_SSL_CERTFILE") or None
-
+    DEFAULT_FROM_EMAIL = os.environ.get("EMAIL_FROM") or EMAIL_HOST_USER or ""
 
 # Security
 

--- a/docs/configuration/email.md
+++ b/docs/configuration/email.md
@@ -25,6 +25,12 @@ _Default:_ 25
 
 Port to use for the SMTP server defined in `EMAIL_HOST`.
 
+## `EMAIL_FROM`
+
+_Default:_ `<EMAIL_HOST_USER>` or `webmaster@localhost`
+
+The sender of the email . Can be an email, or name and email : `Baby buddy <babybuddy@example.com>` .
+
 ## `EMAIL_USE_TLS`
 
 _Default:_ `False`


### PR DESCRIPTION
Allow to configure `DEFAULT_FROM_EMAIL` from [django email](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-DEFAULT_FROM_EMAIL) . 

By default, it will populate the from header with `webmaster@localhost` (which can be refused by email provider / or hard to handle on relay based on `From` header ) . 

Because my first reflex was to use the `EMAIL_HOST_USER` to configure it (providers can allow sending only mails with the name of your user), I set it as a default value . 

Fix #866