### PR TITLE
Fix SUB_PATH breakage caused by the new home assistant middleware

### DIFF
--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -143,7 +143,7 @@ class HomeAssistant:
                 request.headers.get("X-Hass-Source") == "core.ingress"
             )
         else:
-            request.is_homeassistant_ingress_request = False
+            return self.get_response(request)
 
         apply_x_ingress_path = True
         if not request.is_homeassistant_ingress_request:


### PR DESCRIPTION
Fix #896

Debugged together with @fs1, sorry for breaking your server! This fully disables any `set_script_prefix` calls if the homeassistant middleware is disabled.

I do not know why the first version did not work, but `get_script_prefix`/`set_script_prefix` are deep, deep django functions, so I cannot quite oversee what the consequences of using them are. Better to bypass the all!