### PR TITLE
Fix AttributeError caused by Home Assistant middleware.

### DIFF
--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -143,6 +143,7 @@ class HomeAssistant:
                 request.headers.get("X-Hass-Source") == "core.ingress"
             )
         else:
+            request.is_homeassistant_ingress_request = False
             return self.get_response(request)
 
         apply_x_ingress_path = True


### PR DESCRIPTION
This resolves an issue I noticed in /user/add-device where it would try to reference `request.is_homeassistant_ingress_request` but it doesn't exist when Home Assistant support is disabled.

This preserves the early return in #899 but brings back setting the value to False so we don't have to rewrite validation wherever this reference is made.