### PR TITLE
fix: weight and height percentile plotting error due to date range

### DIFF
--- a/reports/graphs/height_change.py
+++ b/reports/graphs/height_change.py
@@ -44,8 +44,8 @@ def height_change(
 
         # reduce percentile data xrange to end 1 day after last height measurement in for formatting purposes
         # https://github.com/babybuddy/babybuddy/pull/708#discussion_r1332335789
-        last_date_for_percentiles = max(measuring_dates) + timedelta(days=2)
-        dates = dates[: dates.index(last_date_for_percentiles)]
+        last_date_for_percentiles = min(max(dates), max(measuring_dates))
+        dates = dates[: dates.index(last_date_for_percentiles) + 1]
 
         percentile_height_3_trace = go.Scatter(
             name=_("P3"),

--- a/reports/graphs/weight_change.py
+++ b/reports/graphs/weight_change.py
@@ -42,8 +42,8 @@ def weight_change(
 
         # reduce percentile data xrange to end 1 day after last weigh in for formatting purposes
         # https://github.com/babybuddy/babybuddy/pull/708#discussion_r1332335789
-        last_date_for_percentiles = max(weighing_dates) + timedelta(days=2)
-        dates = dates[: dates.index(last_date_for_percentiles)]
+        last_date_for_percentiles = min(max(dates), max(weighing_dates))
+        dates = dates[: dates.index(last_date_for_percentiles) + 1]
 
         percentile_weight_3_trace = go.Scatter(
             name=_("P3"),


### PR DESCRIPTION
When a measuring date for weight/height is on or after the last available date in the WHO percentile data, plotting errors out. This fix limits the date range to either the last measuring date or the last WHO percentile data date, whichever is earlier.