### PR TITLE
Fix database url configuration option not functional

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -109,7 +109,7 @@ TEMPLATES = [
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-if os.getenv("DATABSE_URL"):
+if os.getenv("DATABASE_URL"):
     DATABASES = {"default": dj_database_url.config()}
 else:
     config = {

--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -1,6 +1,6 @@
 # Database
 
-## `DATABSE_URL`
+## `DATABASE_URL`
 
 _Default:_ unset
 


### PR DESCRIPTION
providing DATABASE_URL was ignored and providing typo'd DATABSE_URL resulted in
```
WARNING:root:No DATABASE_URL environment variable set, and so no databases setup
```
and an empty, defunctional django database configuration so no need for backward compatability