### PR TITLE
fix: don't display check button input elements

### DIFF
--- a/babybuddy/templates/babybuddy/form_field_no_label.html
+++ b/babybuddy/templates/babybuddy/form_field_no_label.html
@@ -1,9 +1,9 @@
 {% load widget_tweaks %}
 {% if field|field_type == "booleanfield" %}
     {% if field.errors %}
-        {{ field|add_class:"btn-check is-invalid" }}
+        {{ field|add_class:"btn-check d-none is-invalid" }}
     {% else %}
-        {{ field|add_class:"btn-check" }}
+        {{ field|add_class:"btn-check d-none" }}
     {% endif %}
     <label for="id_{{ field.name }}" class="btn btn-outline-light btn-no-hover">{{ field.label }}</label>
 {% elif 'choice' in field|field_type %}

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -88,11 +88,11 @@ class ChildRadioSelect(RadioSelect):
     input_type = "radio"
     template_name = "core/child_radio.html"
     option_template_name = "core/child_radio_option.html"
-    attrs = {"class": "btn-check"}
+    attrs = {"class": "btn-check d-none"}
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
-        attrs["class"] += " btn-check"
+        attrs["class"] += " btn-check d-none"
         return attrs
 
     def create_option(
@@ -111,9 +111,9 @@ class PillRadioSelect(RadioSelect):
     template_name = "core/pill_radio.html"
     option_template_name = "core/pill_radio_option.html"
 
-    attrs = {"class": "btn-check"}
+    attrs = {"class": "btn-check d-none"}
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
-        attrs["class"] += " btn-check"
+        attrs["class"] += " btn-check d-none"
         return attrs


### PR DESCRIPTION
The form submit button in Chrome is not positioned correctly when the page also has an input element with .btn-check.

Not displaying these elements somehow resolves the issue, though it is not clear how.

see: https://github.com/twbs/bootstrap/issues/39097

ref: #945