### PR TITLE
Add django-allauth support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 boto3 = "*"
 dj-database-url = "*"
 django = "~=5.1.1"
+django-allauth = {extras = ["socialaccount"], version = "*"}
 django-axes = "*"
 django-filter = "*"
 django-imagekit = "*"

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -56,6 +56,10 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "allauth.socialaccount.providers.openid_connect",
 ]
 
 # Middleware
@@ -77,6 +81,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "axes.middleware.AxesMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 
@@ -100,6 +105,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
             ],
         },
     },
@@ -154,6 +160,7 @@ WSGI_APPLICATION = "babybuddy.wsgi.application"
 AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
     "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
 ]
 
 LOGIN_REDIRECT_URL = "babybuddy:root-router"

--- a/babybuddy/settings/development.py
+++ b/babybuddy/settings/development.py
@@ -18,6 +18,31 @@ STORAGES["staticfiles"][
     "BACKEND"
 ] = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
+# INSTALLED_APPS = [
+#    "allauth.socialaccount",
+#    "allauth.socialaccount.providers.openid_connect",
+# ]
+
+os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
+os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
+
+SOCIALACCOUNT_PROVIDERS = {
+    "openid_connect": {
+        # For each OAuth based provider, either add a ``SocialApp``
+        # (``socialaccount`` app) containing the required client
+        # credentials, or list them here:
+        "APP": {
+            "provider_id": "keycloak",
+            "name": "keycloak",
+            "client_id": "babybuddy",
+            "secret": "m0iaJ5og5Dd5bNdd8Oljb2M5z49FAB4o",
+            "settings": {
+                "server_url": "https://auth.lan:8443/realms/zuhause/.well-known/openid-configuration"
+            },
+        }
+    }
+}
+
 
 # Logging
 # https://docs.djangoproject.com/en/5.0/ref/logging/

--- a/babybuddy/templates/registration/login.html
+++ b/babybuddy/templates/registration/login.html
@@ -1,5 +1,5 @@
 {% extends "registration/base.html" %}
-{% load i18n static widget_tweaks %}
+{% load i18n static widget_tweaks socialaccount %}
 {% block title %}Login{% endblock %}
 {% block content %}
     <form class="login-form" method="post" action="{% url 'babybuddy:login' %}">
@@ -17,6 +17,20 @@
         </div>
         <button class="btn btn-primary w-100 fade-in" type="submit" name="login">{% trans "Login" %}</button>
     </form>
+    {% get_providers as socialaccount_providers %}
+    {% if socialaccount_providers %}
+        <div class="row" style="margin-top: 2vh">
+            <div class="col-sm-12 col-lg-6 col-md-6 offset-lg-3 offset-md-3">
+                <h5>{% trans "Social Login" %}</h5>
+                <span>{% trans 'You can use any of the following providers to sign in.' %}</span>
+                <br />
+                <br />
+                <ul class="socialaccount_providers list-unstyled">
+                    {% include "socialaccount/provider_list.html" with process="login" %}
+                </ul>
+            </div>
+        </div>
+    {% endif %}
     <div class="bg-faded text-center px-4 py-3 rounded-bottom">
         <a href="{% url 'babybuddy:password_reset' %}" name="reset">{% trans "Forgot your password?" %}</a>
     </div>

--- a/babybuddy/templates/socialaccount/login.html
+++ b/babybuddy/templates/socialaccount/login.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+{% block content %}
+    {% if process == "connect" %}
+        <h1>{% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}</h1>
+        <p>
+            {% blocktrans with provider.name as provider %}You are about to connect a new third party account from {{ provider }}.{% endblocktrans %}
+        </p>
+    {% else %}
+        <h1>{% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}</h1>
+        <p>
+            {% blocktrans with provider.name as provider %}You are about to sign in using a third party account from {{ provider }}.{% endblocktrans %}
+        </p>
+    {% endif %}
+    <form method="post">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-success">{% trans "Continue" %}</button>
+    </form>
+{% endblock %}

--- a/babybuddy/templates/socialaccount/provider_list.html
+++ b/babybuddy/templates/socialaccount/provider_list.html
@@ -1,0 +1,129 @@
+{% load i18n %}
+{% load socialaccount %}
+{% get_providers as socialaccount_providers %}
+{% for provider in socialaccount_providers %}
+    {% if provider.id == "openid" %}
+        {% for brand in provider.get_brands %}
+            <li>
+                <a title="{{ brand.name }}"
+                   class="socialaccount_provider {{ provider.id }} {{ brand.id }}"
+                   href="{% provider_login_url provider.id openid=brand.openid_url process=process %}">{{ brand.name }}</a>
+            </li>
+        {% endfor %}
+    {% endif %}
+    <li CLASS="mb-1">
+        {% if provider.id  == 'discord' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn discord-login-button btn-social">
+                    <i class="fab fa-discord"></i> {% trans 'Sign in using' %} Discord
+                </button>
+            </a>
+        {% elif provider.id == 'github' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-github">
+                    <i class="fab fa-github"></i> {% trans 'Sign in using' %} Github
+                </button>
+            </a>
+        {% elif provider.id == 'reddit' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-reddit">
+                    <i class="fab fa-reddit"></i> {% trans 'Sign in using' %} Reddit
+                </button>
+            </a>
+        {% elif provider.id == 'twitter' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-twitter">
+                    <i class="fab fa-twitter"></i> {% trans 'Sign in using' %} Twitter
+                </button>
+            </a>
+        {% elif provider.id == 'dropbox' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-dropbox">
+                    <i class="fab fa-dropbox"></i> {% trans 'Sign in using' %} Dropbox
+                </button>
+            </a>
+        {% elif provider.id == 'google' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-google">
+                    <i class="fab fa-google"></i> {% trans 'Sign in using' %} Google
+                </button>
+            </a>
+        {% elif provider.id == 'facebook' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-facebook">
+                    <i class="fab fa-facebook"></i> {% trans 'Sign in using' %} Facebook
+                </button>
+            </a>
+        {% elif provider.id == 'instagram' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-instagram">
+                    <i class="fab fa-instagram"></i> {% trans 'Sign in using' %} Instagram
+                </button>
+            </a>
+        {% elif provider.id == 'flickr' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-flickr">
+                    <i class="fab fa-flickr"></i> {% trans 'Sign in using' %} Flickr
+                </button>
+            </a>
+        {% elif provider.id == 'apple' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-apple">
+                    <i class="fab fa-apple"></i> {% trans 'Sign in using' %} Apple
+                </button>
+            </a>
+        {% elif provider.id == 'pinterest' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-pinterest">
+                    <i class="fab fa-pinterest"></i> {% trans 'Sign in using' %} Pinterest
+                </button>
+            </a>
+        {% elif provider.id == 'windowslive' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-microsoft">
+                    <i class="fab fa-microsoft"></i> {% trans 'Sign in using' %} Microsoft Live
+                </button>
+            </a>
+        {% elif provider.id == 'yahoo' %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-yahoo">
+                    <i class="fab fa-yahoo"></i> {% trans 'Sign in using' %} Yahoo
+                </button>
+            </a>
+        {% else %}
+            <a title="{{ provider.name }}"
+               class="socialaccount_provider {{ provider.id }}"
+               href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+                <button class="btn btn-social btn-success">
+                    <i class="fas fa-sign-in-alt"></i> {% trans 'Sign in using' %} {{ provider.name }}
+                </button>
+            </a>
+        {% endif %}
+    </li>
+{% endfor %}

--- a/babybuddy/urls.py
+++ b/babybuddy/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
     path("", include("core.urls", namespace="core")),
     path("", include("dashboard.urls", namespace="dashboard")),
     path("", include("reports.urls", namespace="reports")),
+    path("accounts/", include("allauth.urls")),
 ]
 
 if settings.DEBUG:  # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ botocore==1.36.26; python_version >= '3.8'
 diff-match-patch==20241021; python_version >= '3.7'
 dj-database-url==2.3.0
 django==5.1.6; python_version >= '3.10'
+django-allauth[socialaccount]==65.7.0
 django-appconf==1.1.0; python_version >= '3.9'
 django-axes==7.0.2; python_version >= '3.7'
 django-cors-headers==4.7.0; python_version >= '3.9'


### PR DESCRIPTION
This is related to bug #907. Using [django-allauth](https://docs.allauth.org/en/latest/), add the possibility to register and login via SSO to every supported provider. There are still some things to fix, however, other than the documentation.

Disclaimer: I'm neither a python nor frontend developer, so I'm not sure what I'm doing. Most of the code (which is only frontend code) is shamelessly copied from [Tandoor](https://github.com/TandoorRecipes/recipes), a recipe app.

If there's a provided enabled, the login page will look like this:
![image](https://github.com/user-attachments/assets/25f602c2-70d8-4607-8b1d-c73dc392c0a5)
It should list every enabled provided. I only tested with keycloak because it's what I use. Clicking that button will redirect to another page, which is very ugly because I don't know how to do frontend, much less as python templates, so this would need work before merging, of course:

![image](https://github.com/user-attachments/assets/daeadf52-38bf-420c-968b-daf8724bcfe0)

Pressing the "Continue" button will redirect to the actual keycloak (in this case) login site, and after successful login, the user will be simply logged in:

![image](https://github.com/user-attachments/assets/929c9625-1c44-4a0f-a09c-382d5cc944a5)

Other than the aforementioned ugly login page, there are some things that might need to be fixed:

In the `INSTALLED_APPS` section of the `base.py` settings file, at the end, I commited the app `"allauth.socialaccount.providers.openid_connect"`.  I wanted this to be a user setting in the production (or development) settings file, but as I said, I don't know python, and my attempts for django to use both sections in both files failed. Maybe somebody can help in this topic?

About the use, one should simply configure allauth in the settings file [according to the documentation](https://docs.allauth.org/en/latest/socialaccount/provider_configuration.html). As an example, for my case, this is what was working for my keycloak installation (provided that there's a client for babybuddy there, it's configured correctly, etc., but this is outside the scope):

```
SOCIALACCOUNT_PROVIDERS = {
    "openid_connect": {
        "APP": {
            "provider_id": "keycloak",
            "name": "keycloak",
            "client_id": "babybuddy",
            "secret": "*****",
            "settings": {
                "server_url": "REALM_URL/.well-known/openid-configuration"
            },
        }
    }
}
```

Summarizing, with minimal changes, we can add SSO support via OpenID connect, Oauth2, or any other popular provider to the app.


