### PR TITLE
Feeding history as Graph using ChartJS (PoC)

### DIFF
--- a/babybuddy/templates/babybuddy/base.html
+++ b/babybuddy/templates/babybuddy/base.html
@@ -25,7 +25,6 @@
         <link rel="shortcut icon"
               href="{% static "babybuddy/root/favicon.ico" %}?v=20211218" />
         <link rel="stylesheet" href="{% static "babybuddy/css/app.css" %}" />
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="Baby Buddy" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />

--- a/babybuddy/templates/babybuddy/base.html
+++ b/babybuddy/templates/babybuddy/base.html
@@ -25,6 +25,7 @@
         <link rel="shortcut icon"
               href="{% static "babybuddy/root/favicon.ico" %}?v=20211218" />
         <link rel="stylesheet" href="{% static "babybuddy/css/app.css" %}" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="Baby Buddy" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />

--- a/dashboard/templates/cards/feeding_history_graph.html
+++ b/dashboard/templates/cards/feeding_history_graph.html
@@ -1,0 +1,39 @@
+{% extends 'cards/base.html' %}
+{% load duration i18n %}
+{% block header %}
+    <a href="{% url "core:feeding-list" %}">{% trans "Feeding History" %}</a>
+{% endblock %}
+{% block title %}
+{% endblock %}
+{% block content %}
+{% if feeding %}
+<div id="feeding-history-graph">
+      <table class="charts-css line multiple hide-data show-labels show-secondary-axes">
+        <caption> Line Example #5 </caption>
+        <thead>
+          <tr>
+            <th scope="col"> Day </th>
+            {% for graph in graphs.0 %}
+            <th scope="col">{{ forloop.counter0 }}h</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+            {% for graph in graphs %}
+            <tr>
+                <th scope="row">{{ forloop.counter0 }}h</th>
+                {% for entry in graph %}
+                <td style="--start: {{ entry.0 }}; --end: {{ entry.1}}; --color: {% cycle 'red' '#C0C0C0' '#A0A0A0' '#808080' '#606060' '#404040' '#202020' %};{% if forloop.counter0 == 0 %} --size: 10px;{% endif %}">
+                    <span class="data"> {{ entry.2 }} </span>
+                </td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+      </table>
+</div>
+{% else %}
+    {% trans "None" %}
+{% endif %}
+{% endblock %}
+

--- a/dashboard/templates/cards/feeding_history_graph.html
+++ b/dashboard/templates/cards/feeding_history_graph.html
@@ -8,29 +8,25 @@
 {% block content %}
 {% if feeding %}
 <div id="feeding-history-graph">
-      <table class="charts-css line multiple hide-data show-labels show-secondary-axes">
-        <caption> Line Example #5 </caption>
-        <thead>
-          <tr>
-            <th scope="col"> Day </th>
-            {% for graph in graphs.0 %}
-            <th scope="col">{{ forloop.counter0 }}h</th>
-            {% endfor %}
-          </tr>
-        </thead>
-        <tbody>
-            {% for graph in graphs %}
-            <tr>
-                <th scope="row">{{ forloop.counter0 }}h</th>
-                {% for entry in graph %}
-                <td style="--start: {{ entry.0 }}; --end: {{ entry.1}}; --color: {% cycle 'red' '#C0C0C0' '#A0A0A0' '#808080' '#606060' '#404040' '#202020' %};{% if forloop.counter0 == 0 %} --size: 10px;{% endif %}">
-                    <span class="data"> {{ entry.2 }} </span>
-                </td>
-                {% endfor %}
-            </tr>
-            {% endfor %}
-        </tbody>
-      </table>
+  <canvas id="feeding-history-graph-chart"></canvas>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+  <script>
+    const ctx = document.getElementById('feeding-history-graph-chart');
+
+    new Chart(ctx, {
+      type: 'line',
+      data: {{graphs_json|safe}},
+      options: {
+        scales: {
+          y: {
+            beginAtZero: true
+          }
+        }
+      }
+    });
+  </script>
 </div>
 {% else %}
     {% trans "None" %}

--- a/dashboard/templates/cards/feeding_history_graph.html
+++ b/dashboard/templates/cards/feeding_history_graph.html
@@ -3,33 +3,29 @@
 {% block header %}
     <a href="{% url "core:feeding-list" %}">{% trans "Feeding History" %}</a>
 {% endblock %}
-{% block title %}
-{% endblock %}
+{% block title %}{% endblock %}
 {% block content %}
-{% if feeding %}
-<div id="feeding-history-graph">
-  <canvas id="feeding-history-graph-chart"></canvas>
+    {% if feeding %}
+        <div id="feeding-history-graph">
+            <canvas id="feeding-history-graph-chart"></canvas>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+            <script>
+                const ctx = document.getElementById('feeding-history-graph-chart');
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
-  <script>
-    const ctx = document.getElementById('feeding-history-graph-chart');
-
-    new Chart(ctx, {
-      type: 'line',
-      data: {{graphs_json|safe}},
-      options: {
-        scales: {
-          y: {
-            beginAtZero: true
-          }
-        }
-      }
-    });
-  </script>
-</div>
-{% else %}
-    {% trans "None" %}
-{% endif %}
+                new Chart(ctx, {
+                  type: 'line',
+                  data: {{graphs_json|safe}},
+                  options: {
+                    scales: {
+                      y: {
+                        beginAtZero: true
+                      }
+                    }
+                  }
+                });
+            </script>
+        </div>
+    {% else %}
+        {% trans "None" %}
+    {% endif %}
 {% endblock %}
-

--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -21,6 +21,7 @@
         <div class="col-sm-6 col-lg-4">{% card_sleep_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_feeding_last_method object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_feeding_recent object %}</div>
+        <div class="col-sm-6 col-lg-4">{% card_feeding_history_graph object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_statistics object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_sleep_recent object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_sleep_naps_day object %}</div>

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -323,8 +323,7 @@ def card_feeding_history_graph(context, child):
 
     return {
         "type": "feeding",
-        "feeding": 1,
-        "graphs": graphs,
+        "feeding": instances,
         "graphs_json": json.dumps(graphs),
         "empty": empty,
         "hide_empty": _hide_empty(context),

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -279,7 +279,7 @@ def card_feeding_history_graph(context, child):
 
     graphs = {"labels": [f"{i}h" for i in range(24)], "datasets": []}
     colors = [
-        "red",
+        "#37abe9",
         "#FFFFFF",
         "#E0E0E0",
         "#C0C0C0",


### PR DESCRIPTION
Hi !

We wanted a quick way to compare the feeding amount day-by-day from the main dashboard.
I quickly implemented a demo how what it could be (the code probably has room for lots of improvements).

Here's what it looks like:

![image](https://github.com/user-attachments/assets/55e84789-f02a-4ec0-93ec-bdef7a97a941)

For now I'm really not happy with generating the JSON payload server side and printing it in the template but I didn't want to start to play with new endpoints etc. 

I'm also aware that it's not something everyone would want: maybe it's possible to add another flag on the user profile page to enable/disable those kind of graphs ?

What are your opinions about such feature ?