### PR TITLE
fix: preserve Set-Cookie when Home Assistant ingress rewrites HTML

### DIFF
--- a/babybuddy/middleware.py
+++ b/babybuddy/middleware.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from os import getenv
 from time import time
@@ -216,6 +217,11 @@ class HomeAssistant:
                         for key, value in response.headers.items()
                         if not key.lower().startswith("content-")
                     }
+                    # Set-Cookie (CSRF, session) lives on response.cookies; it is not
+                    # reliably present in response.headers.items(). Rebuilding
+                    # HttpResponse without copying drops csrftoken/sessionid behind
+                    # Home Assistant ingress.
+                    preserved_cookies = copy.copy(response.cookies)
                     response = HttpResponse(
                         content.encode(),
                         status=response.status_code,
@@ -223,5 +229,6 @@ class HomeAssistant:
                         charset=response.charset,
                         headers=filtered_headers,
                     )
+                    response.cookies = preserved_cookies
 
         return response

--- a/babybuddy/tests/tests_home_assistant.py
+++ b/babybuddy/tests/tests_home_assistant.py
@@ -67,3 +67,24 @@ class HomeAssistantMiddlewareTestCase(TestCase):
         self.assertEqual(
             json_response["profile"], "http://testserver/magic/sub/url/api/profile"
         )
+
+    def test_ingress_html_preserves_response_cookies(self):
+        """
+        Ingress rewrites text/html; rebuilt HttpResponse must copy response.cookies
+        so Set-Cookie (CSRF, session) is not dropped. Uses the real middleware stack
+        (same as production) so behavior matches Client requests with ingress headers.
+        """
+        response = self.c.get(
+            "/login/",
+            headers={
+                "X-Hass-Source": "core.ingress",
+                "X-Ingress-Path": "/hassio/ingress/baby_buddy",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/html", response.get("Content-Type", ""))
+        self.assertIn(
+            "csrftoken",
+            response.cookies,
+            "Ingress HTML rewrite must preserve CSRF Set-Cookie",
+        )


### PR DESCRIPTION
The HomeAssistant middleware rebuilds text/html responses to prefix static and media URLs. It copied only response.headers into the new HttpResponse; Django stores csrftoken and sessionid on response.cookies, so browsers never received those cookies and CSRF/login failed behind ingress.

Copy response.cookies onto the rebuilt response (same pattern as add-on patch).

This is needed for a full fix for https://github.com/OttPeterR/addon-babybuddy/issues/81 (the Home Assistant Add On, AKA App now, that bundles Baby Buddy into the Home Assistant UI) which I am working on a larger fix for here:
https://github.com/OttPeterR/addon-babybuddy/pull/88

Made-with: Cursor