### PR TITLE
Add Recent Pumpings dashboard widget

### DIFF
--- a/dashboard/templates/cards/pumping_recent.html
+++ b/dashboard/templates/cards/pumping_recent.html
@@ -1,0 +1,54 @@
+{% extends 'cards/base.html' %}
+{% load duration i18n %}
+{% block header %}
+    <a href="{% url "core:pumping-list" %}">{% trans "Recent Pumpings" %}</a>
+{% endblock %}
+{% block title %}
+    {% if pumpings|length > 0 %}
+        <div id="pumping-days-carousel"
+             class="carousel slide"
+             data-bs-interval="false">
+            <div class="carousel-inner">
+                {% for pumping in pumpings %}
+                    <div class="carousel-item{% if forloop.counter == 1 %} active{% endif %}">
+                        <div class="last-feeding-method text-center">
+                            {% if pumping.total %}
+                                {{ pumping.total|floatformat }}
+                            {% else %}
+                                {% trans "None" %}
+                            {% endif %}
+                        </div>
+                        <div class="text-center small">
+                            {% if pumping.count > 0 %}
+                                {% blocktrans trimmed count counter=pumping.count %}
+                                    {{ counter }} pumping
+                                {% plural %}
+                                    {{ counter }} pumpings
+                                {% endblocktrans %}
+                            {% endif %}
+                        </div>
+                        <div class="text-center small text-body-secondary">{{ pumping.date.date|dayssince }}</div>
+                    </div>
+                {% endfor %}
+            </div>
+            {% if pumpings|length > 1 %}
+                <a class="carousel-control-prev"
+                   href="#pumping-days-carousel"
+                   role="button"
+                   data-bs-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">{% trans "Previous" %}</span>
+                </a>
+                <a class="carousel-control-next"
+                   href="#pumping-days-carousel"
+                   role="button"
+                   data-bs-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">{% trans "Next" %}</span>
+                </a>
+            {% endif %}
+        </div>
+    {% else %}
+        {% trans "None" %}
+    {% endif %}
+{% endblock %}

--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -18,6 +18,7 @@
         <div class="col-sm-6 col-lg-4">{% card_feeding_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_diaperchange_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_pumping_last object %}</div>
+        <div class="col-sm-6 col-lg-4">{% card_pumping_recent object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_sleep_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_feeding_last_method object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_feeding_recent object %}</div>

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -292,6 +292,44 @@ def card_pumping_last(context, child):
     }
 
 
+@register.inclusion_tag("cards/pumping_recent.html", takes_context=True)
+def card_pumping_recent(context, child, end_date=None):
+    """
+    Filters Pumping instances to get total amount for a specific date and for 7 days before.
+    :param child: an instance of the Child model.
+    :param end_date: a Date object for the day to filter.
+    :returns: a dict with count and total amount for the Pumping instances.
+    """
+    if not end_date:
+        end_date = timezone.localtime()
+
+    end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=9999)
+    start_date = end_date - timezone.timedelta(days=8)
+
+    instances = models.Pumping.objects.filter(child=child).filter(
+        start__range=[start_date, end_date]
+    )
+
+    dates = [end_date - timezone.timedelta(days=i) for i in range(8)]
+    results = [{"date": d, "total": 0, "count": 0} for d in dates]
+
+    for instance in instances:
+        pump_date = timezone.localtime(instance.end).replace(
+            hour=23, minute=59, second=59, microsecond=9999
+        )
+        idx = (end_date - pump_date).days
+        result = results[idx]
+        result["total"] += instance.amount if instance.amount is not None else 0
+        result["count"] += 1
+
+    return {
+        "pumpings": results,
+        "type": "pumping",
+        "empty": len(instances) == 0,
+        "hide_empty": _hide_empty(context),
+    }
+
+
 @register.inclusion_tag("cards/sleep_last.html", takes_context=True)
 def card_sleep_last(context, child):
     """

--- a/dashboard/tests/tests_templatetags.py
+++ b/dashboard/tests/tests_templatetags.py
@@ -203,6 +203,31 @@ class TemplateTagsTestCase(TestCase):
         self.assertIsInstance(data["pumping"], models.Pumping)
         self.assertEqual(data["pumping"], models.Pumping.objects.first())
 
+    def test_card_pumping_recent(self):
+        data = cards.card_pumping_recent(self.context, self.child, self.date)
+        self.assertEqual(data["type"], "pumping")
+        self.assertFalse(data["empty"])
+        self.assertFalse(data["hide_empty"])
+
+        # 8 days of data returned
+        self.assertEqual(len(data["pumpings"]), 8)
+
+        # Fixture has 2 pumpings on 2017-11-17 (amounts 5.0 and 9.0).
+        # self.date is 2017-11-18, so 2017-11-17 is index 1 (yesterday).
+        self.assertEqual(data["pumpings"][1]["total"], 14.0)
+        self.assertEqual(data["pumpings"][1]["count"], 2)
+
+        # Today (2017-11-18) should have no pumpings.
+        self.assertEqual(data["pumpings"][0]["total"], 0)
+        self.assertEqual(data["pumpings"][0]["count"], 0)
+
+    def test_card_pumping_recent_empty(self):
+        models.Pumping.objects.all().delete()
+        data = cards.card_pumping_recent(self.context, self.child, self.date)
+        self.assertEqual(data["type"], "pumping")
+        self.assertTrue(data["empty"])
+        self.assertFalse(data["hide_empty"])
+
     def test_card_sleep_last(self):
         data = cards.card_sleep_last(self.context, self.child)
         self.assertEqual(data["type"], "sleep")


### PR DESCRIPTION
Adds a "Recent Pumpings" dashboard card that displays daily pumping totals and session counts for the past 8 days in a Bootstrap carousel, matching the pattern used by the existing "Recent Feedings" card.

## Changes

- New `card_pumping_recent` template tag in `dashboard/templatetags/cards.py`
- New `cards/pumping_recent.html` template with carousel navigation
- Card added to the child dashboard layout
- Tests for the new template tag (populated and empty states)

## Testing

- `gulp test` passes (299 + 1 tests, 0 failures)

Closes #1037 
