### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.kiro
+data
+*.tar
+*.tar.gz
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:20-slim AS assets
+
+WORKDIR /build
+COPY package.json package-lock.json gulpfile.js gulpfile.config.js ./
+RUN npm install --ignore-scripts
+COPY . .
+RUN npx gulp build
+
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -14,6 +22,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+COPY --from=assets /build/babybuddy/static/babybuddy/ /app/babybuddy/static/babybuddy/
 
 RUN python manage.py collectstatic --noinput
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DJANGO_SETTINGS_MODULE=babybuddy.settings.base
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN python manage.py collectstatic --noinput
+
+EXPOSE 80
+
+CMD ["bash", "-c", "python manage.py migrate && gunicorn babybuddy.wsgi:application --bind 0.0.0.0:80 --timeout 30 --log-file -"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpq-dev gcc && \
+    libpq-dev default-libmysqlclient-dev pkg-config gcc && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -25,6 +25,8 @@ COPY . .
 COPY --from=assets /build/babybuddy/static/babybuddy/ /app/babybuddy/static/babybuddy/
 
 RUN python manage.py collectstatic --noinput
+
+VOLUME ["/app/data", "/app/media"]
 
 EXPOSE 80
 

--- a/docs/setup/deployment.md
+++ b/docs/setup/deployment.md
@@ -49,6 +49,54 @@ Note: the container name (`babybuddy`) and secret key location
 (`/config/.secretkey`) may differ depending on the container configuration.
 Refer to the running containers configuration for these values.
 
+### Building from source
+
+Baby Buddy also includes a Dockerfile in the repository for building a container
+image directly from source. This is useful for running a custom branch, testing
+changes, or deployments that don't need the LinuxServer.io infrastructure.
+
+The image uses a multi-stage build (Node for frontend assets, Python for the
+application) and supports both PostgreSQL and MySQL/MariaDB databases.
+
+```shell
+git clone https://github.com/babybuddy/babybuddy.git
+cd babybuddy
+docker build -t babybuddy .
+```
+
+Example Docker Compose configuration:
+
+```yaml
+version: "3.8"
+services:
+  babybuddy:
+    build: .
+    container_name: babybuddy
+    volumes:
+      - data:/app/data
+      - media:/app/media
+    ports:
+      - 8000:80
+    environment:
+      - SECRET_KEY=<CHANGE TO SOMETHING RANDOM>
+      - DJANGO_SETTINGS_MODULE=babybuddy.settings.base
+      - ALLOWED_HOSTS=*
+    restart: unless-stopped
+
+volumes:
+  data:
+  media:
+```
+
+The default database is SQLite stored at `/app/data/db.sqlite3`. To use
+PostgreSQL or MySQL, set the `DATABASE_URL` environment variable or the
+individual `DB_ENGINE`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and `DB_HOST`
+variables. See [Database configuration](../configuration/database.md) for
+details.
+
+Uploaded media (e.g., child photos) is stored at `/app/media`. Mount a volume
+at this path to persist uploads across container recreations.
+
 ## Home Assistant
 
 [Home Assistant](https://www.home-assistant.io/) is an open source home automation tool


### PR DESCRIPTION
Adds a Dockerfile and `.dockerignore` for building Baby Buddy as a container image.

## Changes

- Multi-stage Dockerfile: `node:20-slim` stage builds frontend assets via Gulp, `python:3.11-slim` stage runs the application with Gunicorn
- `.dockerignore` to keep the build context clean (excludes `node_modules`, `.git`, `data/`, etc.)
- Runs `collectstatic` at build time
- Exposes port 80, runs migrations on startup

## Usage

    docker build -t babybuddy .
    docker run -p 8000:80 babybuddy

## Testing

- `gulp test` passes (297 + 1 tests, 0 failures) — no application code changed
- Image builds and starts successfully

Closes #1039 