### PR TITLE
Redirect user to settings page after password change

### DIFF
--- a/babybuddy/views.py
+++ b/babybuddy/views.py
@@ -183,11 +183,13 @@ class UserPassword(LoginRequiredMixin, View):
         )
 
     def post(self, request):
-        form = PasswordChangeForm(request.user, request.POST)
+        form = self.form_class(request.user, request.POST)
         if form.is_valid():
             user = form.save()
             update_session_auth_hash(request, user)
             messages.success(request, _("Password updated."))
+            return redirect("babybuddy:user-settings")
+        messages.error(request, _("Please correct the errors below."))
         return render(request, self.template_name, {"form": form})
 
 


### PR DESCRIPTION
修复密码修改成功后未重定向到用户设置页面的问题，并在表单验证失败时显示错误信息