### PR TITLE
Make DB options a dictionary type to be handed to the DB engine

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -127,7 +127,8 @@ else:
     if os.getenv("DB_PORT"):
         config["PORT"] = os.getenv("DB_PORT")
     if os.getenv("DB_OPTIONS"):
-        config["OPTIONS"] = os.getenv("DB_OPTIONS")
+        import ast
+        config["OPTIONS"] = ast.literal_eval(os.getenv("DB_OPTIONS"))
     DATABASES = {"default": config}
 
 

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -1,3 +1,4 @@
+import json
 import os
 import dj_database_url
 
@@ -127,9 +128,7 @@ else:
     if os.getenv("DB_PORT"):
         config["PORT"] = os.getenv("DB_PORT")
     if os.getenv("DB_OPTIONS"):
-        import ast
-        
-        config["OPTIONS"] = ast.literal_eval(os.getenv("DB_OPTIONS"))
+        config["OPTIONS"] = json.loads(os.getenv("DB_OPTIONS", "{}"))
     DATABASES = {"default": config}
 
 

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -128,6 +128,7 @@ else:
         config["PORT"] = os.getenv("DB_PORT")
     if os.getenv("DB_OPTIONS"):
         import ast
+        
         config["OPTIONS"] = ast.literal_eval(os.getenv("DB_OPTIONS"))
     DATABASES = {"default": config}
 

--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -51,4 +51,4 @@ The database username utilized for the deployment.
 
 _Default:_ unset
 
-Additional options to pass to the database library. See the [Django Databases documentation](https://docs.djangoproject.com/en/5.0/ref/databases/) for examples. To enforce an SSL connection to the database, use `{'sslmode': 'require'}`.
+Additional options to pass to the database library. See the [Django Databases documentation](https://docs.djangoproject.com/en/5.0/ref/databases/) for examples. To enforce an SSL connection to the database, use `{"sslmode": "require"}`.


### PR DESCRIPTION
This fixes #1027 

I set the DB_OPTIONS for a sqlite backend with the following: DB_OPTIONS="{'init_command': 'PRAGMA busy_timeout = 5000; PRAGMA journal_mode=wal; PRAGMA synchronous = NORMAL; PRAGMA mmap_size=134217728; PRAGMA journal_size_limit=67108864; PRAGMA cache_size=2000;'}"

Setting the db_options triggers an exception: TypeError: 'str' object is not a mapping

Converting to the dictionary fixes this. I tested with postgres as well -- not sure if there is a test suite you'd prefer me to run to validate this.