### PR TITLE
fix: XFF processing when using a reverse proxy take 2

### DIFF
--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -373,14 +373,6 @@ AXES_COOLOFF_TIME = 1
 
 AXES_FAILURE_LIMIT = 5
 
-AXES_LOCKOUT_TEMPLATE = "error/lockout.html"
-
-AXES_LOCKOUT_URL = "/login/lock"
-
-AXES_COOLOFF_TIME = 1
-
-AXES_FAILURE_LIMIT = 5
-
 # `None` makes Axes use the default precedence order set by django-ipware.
 # See: https://github.com/un33k/django-ipware#precedence-order
 AXES_IPWARE_META_PRECEDENCE_ORDER = None

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -377,29 +377,7 @@ AXES_LOCKOUT_TEMPLATE = "error/lockout.html"
 
 AXES_LOCKOUT_URL = "/login/lock"
 
-AXES_IPWARE_META_PRECEDENCE_ORDER = (
-    "X_FORWARDED_FOR",
-    # Load balancers or proxies such as AWS ELB (default client is `left-most` [`<client>, <proxy1>, <proxy2>`])
-    "HTTP_X_FORWARDED_FOR",  # Similar to X_FORWARDED_TO
-    "HTTP_CLIENT_IP",  # Standard headers used by providers such as Amazon EC2, Heroku etc.
-    "HTTP_X_REAL_IP",  # Standard headers used by providers such as Amazon EC2, Heroku etc.
-    "HTTP_X_FORWARDED",  # Squid and others
-    "HTTP_X_CLUSTER_CLIENT_IP",  # Rackspace LB and Riverbed Stingray
-    "HTTP_FORWARDED_FOR",  # RFC 7239
-    "HTTP_FORWARDED",  # RFC 7239
-    "HTTP_CF_CONNECTING_IP",  # CloudFlare
-    "X-CLIENT-IP",  # Microsoft Azure
-    "X-REAL-IP",  # NGINX
-    "X-CLUSTER-CLIENT-IP",  # Rackspace Cloud Load Balancers
-    "X_FORWARDED",  # Squid
-    "FORWARDED_FOR",  # RFC 7239
-    "CF-CONNECTING-IP",  # CloudFlare
-    "TRUE-CLIENT-IP",  # CloudFlare Enterprise,
-    "FASTLY-CLIENT-IP",  # Firebase, Fastly
-    "FORWARDED",  # RFC 7239
-    "CLIENT-IP",  # Akamai and Cloudflare: True-Client-IP and Fastly: Fastly-Client-IP
-    "REMOTE_ADDR",  # Default
-)
+AXES_IPWARE_META_PRECEDENCE_ORDER = None
 
 # Session configuration
 # Used by RollingSessionMiddleware to determine how often to reset the session.

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -377,7 +377,17 @@ AXES_LOCKOUT_TEMPLATE = "error/lockout.html"
 
 AXES_LOCKOUT_URL = "/login/lock"
 
+AXES_COOLOFF_TIME = 1
+
+AXES_FAILURE_LIMIT = 5
+
+# `None` makes Axes use the default precedence order set by django-ipware.
+# See: https://github.com/un33k/django-ipware#precedence-order
 AXES_IPWARE_META_PRECEDENCE_ORDER = None
+
+AXES_LOCKOUT_TEMPLATE = "error/lockout.html"
+
+AXES_LOCKOUT_URL = "/login/lock"
 
 # Session configuration
 # Used by RollingSessionMiddleware to determine how often to reset the session.

--- a/babybuddy/settings/base.py
+++ b/babybuddy/settings/base.py
@@ -377,6 +377,30 @@ AXES_LOCKOUT_TEMPLATE = "error/lockout.html"
 
 AXES_LOCKOUT_URL = "/login/lock"
 
+AXES_IPWARE_META_PRECEDENCE_ORDER = (
+    "X_FORWARDED_FOR",
+    # Load balancers or proxies such as AWS ELB (default client is `left-most` [`<client>, <proxy1>, <proxy2>`])
+    "HTTP_X_FORWARDED_FOR",  # Similar to X_FORWARDED_TO
+    "HTTP_CLIENT_IP",  # Standard headers used by providers such as Amazon EC2, Heroku etc.
+    "HTTP_X_REAL_IP",  # Standard headers used by providers such as Amazon EC2, Heroku etc.
+    "HTTP_X_FORWARDED",  # Squid and others
+    "HTTP_X_CLUSTER_CLIENT_IP",  # Rackspace LB and Riverbed Stingray
+    "HTTP_FORWARDED_FOR",  # RFC 7239
+    "HTTP_FORWARDED",  # RFC 7239
+    "HTTP_CF_CONNECTING_IP",  # CloudFlare
+    "X-CLIENT-IP",  # Microsoft Azure
+    "X-REAL-IP",  # NGINX
+    "X-CLUSTER-CLIENT-IP",  # Rackspace Cloud Load Balancers
+    "X_FORWARDED",  # Squid
+    "FORWARDED_FOR",  # RFC 7239
+    "CF-CONNECTING-IP",  # CloudFlare
+    "TRUE-CLIENT-IP",  # CloudFlare Enterprise,
+    "FASTLY-CLIENT-IP",  # Firebase, Fastly
+    "FORWARDED",  # RFC 7239
+    "CLIENT-IP",  # Akamai and Cloudflare: True-Client-IP and Fastly: Fastly-Client-IP
+    "REMOTE_ADDR",  # Default
+)
+
 # Session configuration
 # Used by RollingSessionMiddleware to determine how often to reset the session.
 # See https://docs.djangoproject.com/en/5.0/topics/http/sessions/


### PR DESCRIPTION
While tesing I observed that the reverse proxy ip address was again logged.
`AXES_IPWARE_META_PRECEDENCE_ORDER` gets initialized somewhere, setting it as None enables inheriting the upstream