### PR TITLE
docs: Document the Baby Buddy MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This is a non-exhaustive list of neat projects and blog posts that either extend
 or use Baby Buddy in fun ways. If you have a project to share please open a PR
 adding it here or reach out via GitHub Issues or Discussions or on Gitter!
 
+### AI
+
+- [Baby Buddy MCP server](https://github.com/babybuddy/babybuddy-mcp) - A [Model Context Protocol](https://modelcontextprotocol.io) server for logging and querying Baby Buddy data with AI assistants. See the [MCP documentation](https://docs.baby-buddy.net/mcp/).
+
 ### Smart home
 
 - [Home Assistant Addon](https://github.com/OttPeterR/addon-babybuddy) (host Baby Buddy on Home Assistant)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,9 +31,10 @@ API token. Generate a token from the User Settings page of the user the assistan
 should act as (see [Authentication](api.md#authentication)).
 
 !!! note
-Installation and configuration — including Docker (`http` transport) and Claude
-Desktop (`stdio` transport) setups and the `BABYBUDDY_URL` / `BABYBUDDY_TOKEN`
-environment variables — are documented in the
-[babybuddy/babybuddy-mcp](https://github.com/babybuddy/babybuddy-mcp) repository.
-Because the server is maintained there, that repository is the source of truth
-for setup steps.
+
+    Installation and configuration — including Docker (`http` transport) and Claude
+    Desktop (`stdio` transport) setups and the `BABYBUDDY_URL` / `BABYBUDDY_TOKEN`
+    environment variables — are documented in the
+    [babybuddy/babybuddy-mcp](https://github.com/babybuddy/babybuddy-mcp) repository.
+    Because the server is maintained there, that repository is the source of truth
+    for setup steps.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,9 +31,9 @@ API token. Generate a token from the User Settings page of the user the assistan
 should act as (see [Authentication](api.md#authentication)).
 
 !!! note
-    Installation and configuration — including Docker (`http` transport) and Claude
-    Desktop (`stdio` transport) setups and the `BABYBUDDY_URL` / `BABYBUDDY_TOKEN`
-    environment variables — are documented in the
-    [babybuddy/babybuddy-mcp](https://github.com/babybuddy/babybuddy-mcp) repository.
-    Because the server is maintained there, that repository is the source of truth
-    for setup steps.
+Installation and configuration — including Docker (`http` transport) and Claude
+Desktop (`stdio` transport) setups and the `BABYBUDDY_URL` / `BABYBUDDY_TOKEN`
+environment variables — are documented in the
+[babybuddy/babybuddy-mcp](https://github.com/babybuddy/babybuddy-mcp) repository.
+Because the server is maintained there, that repository is the source of truth
+for setup steps.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,39 @@
+# MCP Server
+
+Baby Buddy has a [Model Context Protocol](https://modelcontextprotocol.io) (MCP)
+server that lets AI assistants — like Claude Desktop — log and query Baby Buddy
+data using natural language. Ask your assistant to record a feeding, check last
+night's sleep, or summarize the day, and it reads and writes through Baby Buddy's
+[API](api.md).
+
+The server lives in its own repository:
+[**babybuddy/babybuddy-mcp**](https://github.com/babybuddy/babybuddy-mcp).
+
+## What it can do
+
+The server exposes tools grouped by domain, covering create, list, update, and
+delete operations where applicable:
+
+- Children
+- Diaper changes
+- Feedings
+- Sleep
+- Pumping
+- Tummy times
+- Timers
+- Measurements (weight, height, head circumference, BMI, temperature)
+- Notes (and tags)
+
+## Setup
+
+The MCP server connects to a running Baby Buddy instance and authenticates with an
+API token. Generate a token from the User Settings page of the user the assistant
+should act as (see [Authentication](api.md#authentication)).
+
+!!! note
+    Installation and configuration — including Docker (`http` transport) and Claude
+    Desktop (`stdio` transport) setups and the `BABYBUDDY_URL` / `BABYBUDDY_TOKEN`
+    environment variables — are documented in the
+    [babybuddy/babybuddy-mcp](https://github.com/babybuddy/babybuddy-mcp) repository.
+    Because the server is maintained there, that repository is the source of truth
+    for setup steps.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - "contributing/gulp-command-reference.md"
   - "import-export.md"
   - "api.md"
+  - "mcp.md"
 theme:
   name: material
   favicon: assets/images/favicon.svg


### PR DESCRIPTION
## Summary

Documents the Baby Buddy MCP server (per @cdubz's request in #1022).

- Adds a new `docs/mcp.md` page: what the MCP server is, the tool domains it exposes (children, diapers, feedings, sleep, pumping, tummy times, timers, measurements, notes), and a note that it authenticates with an API token. Setup steps deliberately link out to [`babybuddy/babybuddy-mcp`](https://github.com/babybuddy/babybuddy-mcp) so there's a single source of truth.
- Registers the page in the docs nav (`mkdocs.yml`).
- Adds an **AI** subsection to the README's "Baby Buddy on the Web" list linking to the MCP repo.

Refs #1022 (issue already closed — not auto-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)