### PR TITLE
feat(core): add diaper change colors (gray, orange, red, white) + migration

### DIFF
--- a/core/migrations/0037_alter_diaperchange_color.py
+++ b/core/migrations/0037_alter_diaperchange_color.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0036_medication"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="diaperchange",
+            name="color",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("black", "Black"),
+                    ("brown", "Brown"),
+                    ("gray", "Gray"),
+                    ("green", "Green"),
+                    ("orange", "Orange"),
+                    ("red", "Red"),
+                    ("white", "White"),
+                    ("yellow", "Yellow"),
+                ],
+                max_length=255,
+                verbose_name="Color",
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -264,7 +264,11 @@ class DiaperChange(models.Model):
         choices=[
             ("black", _("Black")),
             ("brown", _("Brown")),
+            ("gray", _("Gray")),
             ("green", _("Green")),
+            ("orange", _("Orange")),
+            ("red", _("Red")),
+            ("white", _("White")),
             ("yellow", _("Yellow")),
         ],
         max_length=255,

--- a/core/tests/tests_models.py
+++ b/core/tests/tests_models.py
@@ -110,6 +110,27 @@ class DiaperChangeTestCase(TestCase):
     def test_diaperchange_attributes(self):
         self.assertListEqual(self.change.attributes(), ["Wet", "Solid", "Black"])
 
+    def test_diaperchange_color_choices(self):
+        colors = [
+            choice[0] for choice in models.DiaperChange._meta.get_field("color").choices
+        ]
+        # Create a fresh child so the setUp fixture's DiaperChange doesn't
+        # interfere with the count.
+        child = models.Child.objects.create(
+            first_name="Color", last_name="Test", birth_date=timezone.localdate()
+        )
+        for color in colors:
+            models.DiaperChange.objects.create(
+                child=child,
+                time=timezone.localtime(),
+                wet=False,
+                solid=False,
+                color=color,
+            )
+        self.assertEqual(
+            models.DiaperChange.objects.filter(child=child).count(), len(colors)
+        )
+
 
 class FeedingTestCase(TestCase):
     def setUp(self):

--- a/openapi-schema.yml
+++ b/openapi-schema.yml
@@ -297,7 +297,11 @@ paths:
             enum:
               - black
               - brown
+              - gray
               - green
+              - orange
+              - red
+              - white
               - yellow
         - name: date
           required: false
@@ -427,7 +431,11 @@ paths:
             enum:
               - black
               - brown
+              - gray
               - green
+              - orange
+              - red
+              - white
               - yellow
         - name: date
           required: false
@@ -511,7 +519,11 @@ paths:
             enum:
               - black
               - brown
+              - gray
               - green
+              - orange
+              - red
+              - white
               - yellow
         - name: date
           required: false
@@ -606,7 +618,11 @@ paths:
             enum:
               - black
               - brown
+              - gray
               - green
+              - orange
+              - red
+              - white
               - yellow
         - name: date
           required: false
@@ -701,7 +717,11 @@ paths:
             enum:
               - black
               - brown
+              - gray
               - green
+              - orange
+              - red
+              - white
               - yellow
         - name: date
           required: false
@@ -5661,7 +5681,11 @@ components:
           enum:
             - black
             - brown
+            - gray
             - green
+            - orange
+            - red
+            - white
             - yellow
           type: string
         amount:


### PR DESCRIPTION
## Summary

Adds four new color choices to `DiaperChange.color` for tracking stool colors that indicate common feeding-related variations (orange with breastfeeding) or potential health concerns (gray, red, white for liver/gallbladder issues).

Includes the accompanying migration that was requested in review of #1009.

## Changes

- **`core/models.py`**: Added `gray`, `orange`, `red`, `white` to `DiaperChange.color` choices (alphabetically slotted)
- **`openapi-schema.yml`**: Added the 4 new enum values in all 6 locations
- **`core/migrations/0037_alter_diaperchange_color.py`**: Clean `AlterField` migration scoped to `DiaperChange.color` only

## Relation to #1009

This PR contains the same model/schema changes as #1009 (by @Dashboy1998) plus the migration that was requested in [review](https://github.com/babybuddy/babybuddy/pull/1009#pullrequestreview-4305879807). PR #1009 appears stalled — submitting this complete version so the feature can land.

The migration is hand-written to be surgically scoped to the color field, avoiding bundling unrelated `AlterModelOptions` churn that `makemigrations` auto-generates (same issue noted in #1078).

## Verification

- 258 tests pass (`core` + `api`)
- `black --check` clean on all modified files
- `makemigrations --check` confirms no pending color-related changes
- Tested in a Docker dev environment with the migration applying cleanly

## Notes

- No data migration needed — existing records with the original 4 colors are unaffected
- New choices propagate automatically to forms, serializers, and reports via Django's choice system