### PR TITLE
Fix timeline cross midnight (#942)

### DIFF
--- a/babybuddy/templates/babybuddy/nav-dropdown.html
+++ b/babybuddy/templates/babybuddy/nav-dropdown.html
@@ -15,356 +15,356 @@
             </a>
             <div class="d-lg-none d-md-none d-flex me-auto p-0 ms-2">
                 <div>
-                <a class="text-body-secondary"
-                   href="{% url 'dashboard:dashboard' %}"
-                   aria-expanded="false"><i class="icon-2x icon-dashboard" aria-hidden="true"></i>
-            </a>
-            &nbsp;
-        </div>
-        <div>
-        <a class="text-body-secondary"
-           href="{% url 'core:timeline' %}"
-           aria-expanded="false"><i class="icon-2x icon-timeline" aria-hidden="true"></i>
-    </a>
-    &nbsp;
-</div>
-</div>
-<div class="d-lg-none d-md-none d-flex ms-auto p-0 me-2">
-    {% quick_timer_nav %}
-    <div class="dropdown show">
-    <a class="text-success"
-       href="#"
-       role="button"
-       id="nav-quick-add-link"
-       data-bs-toggle="dropdown"
-       aria-haspopup="true"
-       aria-expanded="false"><i class="icon-2x icon-add" aria-hidden="true"></i>
-</a>
-<div class="dropdown-menu dropdown-menu-end"
-     aria-labelledby="nav-quick-add-link">
-    {% if perms.core.add_diaperchange %}
-        <a class="dropdown-item p-2" href="{% url 'core:diaperchange-add' %}">
-            <i class="icon-diaperchange" aria-hidden="true"></i>
-            {% trans "Diaper Change" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_feeding %}
-        <a class="dropdown-item p-2" href="{% url 'core:feeding-add' %}">
-            <i class="icon-feeding" aria-hidden="true"></i>
-            {% trans "Feeding" %}
-        </a>
-        <a class="dropdown-item p-2" href="{% url 'core:bottle-feeding-add' %}">
-            <i class="icon-feeding" aria-hidden="true"></i>
-            {% trans "Bottle Feeding" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_medication %}
-        <a class="dropdown-item p-2" href="{% url 'core:medication-add' %}">
-            <i class="icon-medication" aria-hidden="true"></i>
-            {% trans "Medication" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_pumping %}
-        <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
-            <i class="icon-pumping" aria-hidden="true"></i>
-            {% trans "Pumping" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_note %}
-        <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
-            <i class="icon-note" aria-hidden="true"></i>
-            {% trans "Note" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_sleep %}
-        <a class="dropdown-item p-2" href="{% url 'core:sleep-add' %}">
-            <i class="icon-sleep" aria-hidden="true"></i>
-            {% trans "Sleep" %}
-        </a>
-    {% endif %}
-    {% if  perms.core.add_tummytime %}
-        <a class="dropdown-item p-2" href="{% url 'core:tummytime-add' %}">
-            <i class="icon-tummytime" aria-hidden="true"></i>
-            {% trans "Tummy Time" %}
-        </a>
-    {% endif %}
-</div>
-</div>
-</div>
-<button class="navbar-toggler"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#navbar-app"
-        aria-controls="navbar-app"
-        aria-expanded="false"
-        aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-</button>
-<div class="collapse navbar-collapse" id="navbar-app">
-    <ul class="navbar-nav me-auto">
-        <li class="nav-item{% if request.path == '/' %} active{% endif %}">
-            <a class="nav-link" href="{% url 'dashboard:dashboard' %}">
-                <i class="icon-dashboard" aria-hidden="true"></i>
-                {% trans "Dashboard" %}
-            </a>
-        </li>
-        <li class="nav-item{% if request.path == '/timeline' %} active{% endif %}">
-            <a class="nav-link" href="{% url 'core:timeline' %}">
-                <i class="icon-timeline" aria-hidden="true"></i>
-                {% trans "Timeline" %}
-            </a>
-        </li>
-        <li class="nav-item dropdown">
-        <a id="nav-children-menu-link"
-           class="nav-link dropdown-toggle"
-           href="#"
-           data-bs-toggle="dropdown"
-           aria-haspopup="true"
-           aria-expanded="false"><i class="icon-child" aria-hidden="true"></i>
-        {% trans "Children" %}
-    </a>
-    <div class="dropdown-menu" aria-labelledby="nav-children-menu-link">
-        {% if perms.core.view_child %}
-            <a class="dropdown-item{% if request.path == '/children/' %} active{% endif %}"
-               href="{% url 'core:child-list' %}">
-                <i class="icon-child" aria-hidden="true"></i>
-                {% trans "Children" %}
-            </a>
-        {% endif %}
-        {% if perms.core.add_child %}
-        <a class="dropdown-item ps-5{% if request.path == '/children/add/' %} active{% endif %}"
-           href="{% url 'core:child-add' %}"><i class="icon-add" aria-hidden="true"></i>
-        {% trans "Child" %}
-    </a>
-{% endif %}
-{% if perms.core.view_note %}
-    <a class="dropdown-item{% if request.path == '/notes/' %} active{% endif %}"
-       href="{% url 'core:note-list' %}">
-        <i class="icon-note" aria-hidden="true"></i>
-        {% trans "Notes" %}
-    </a>
-{% endif %}
-{% if perms.core.add_note %}
-<a class="dropdown-item ps-5{% if request.path == '/notes/add/' %} active{% endif %}"
-   href="{% url 'core:note-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Note" %}
-</a>
-{% endif %}
-</div>
-</li>
-<li class="nav-item dropdown">
-<a id="nav-measurements-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-measurements" aria-hidden="true"></i>
-{% trans "Measurements" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-measurements-menu-link">
-    {% if perms.core.view_bmi %}
-        <a class="dropdown-item{% if request.path == '/bmi/' %} active{% endif %}"
-           href="{% url 'core:bmi-list' %}">
-            <i class="icon-bmi" aria-hidden="true"></i>
-            {% trans "BMI" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_bmi %}
-    <a class="dropdown-item ps-5{% if request.path == '/bmi/add/' %} active{% endif %}"
-       href="{% url 'core:bmi-add' %}"><i class="icon-add" aria-hidden="true"></i>
-    {% trans "BMI entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_head_circumference %}
-    <a class="dropdown-item{% if request.path == '/head-circumference/' %} active{% endif %}"
-       href="{% url 'core:head-circumference-list' %}">
-        <i class="icon-head-circumference" aria-hidden="true"></i>
-        {% trans "Head Circumference" %}
-    </a>
-{% endif %}
-{% if perms.core.add_head_circumference %}
-<a class="dropdown-item ps-5{% if request.path == '/head-circumference/add/' %} active{% endif %}"
-   href="{% url 'core:head-circumference-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Head Circumference entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_height %}
-    <a class="dropdown-item{% if request.path == '/height/' %} active{% endif %}"
-       href="{% url 'core:height-list' %}">
-        <i class="icon-height" aria-hidden="true"></i>
-        {% trans "Height" %}
-    </a>
-{% endif %}
-{% if perms.core.add_height %}
-<a class="dropdown-item ps-5{% if request.path == '/height/add/' %} active{% endif %}"
-   href="{% url 'core:height-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Height entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_temperature %}
-    <a class="dropdown-item{% if request.path == '/temperature/' %} active{% endif %}"
-       href="{% url 'core:temperature-list' %}">
-        <i class="icon-temperature" aria-hidden="true"></i>
-        {% trans "Temperature" %}
-    </a>
-{% endif %}
-{% if perms.core.add_temperature %}
-<a class="dropdown-item ps-5{% if request.path == '/temperature/add/' %} active{% endif %}"
-   href="{% url 'core:temperature-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Temperature reading" %}
-</a>
-{% endif %}
-{% if perms.core.view_weight %}
-    <a class="dropdown-item{% if request.path == '/weight/' %} active{% endif %}"
-       href="{% url 'core:weight-list' %}">
-        <i class="icon-weight" aria-hidden="true"></i>
-        {% trans "Weight" %}
-    </a>
-{% endif %}
-{% if perms.core.add_weight %}
-<a class="dropdown-item ps-5{% if request.path == '/weight/add/' %} active{% endif %}"
-   href="{% url 'core:weight-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Weight entry" %}
-</a>
-{% endif %}
-</div>
-</li>
-<li class="nav-item dropdown">
-<a id="nav-activity-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-activities" aria-hidden="true"></i>
-{% trans "Activities" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-activity-menu-link">
-    {% if perms.core.view_diaperchange %}
-    <a class="dropdown-item{% if request.path == '/changes/' %} active{% endif %}"
-       href="{% url 'core:diaperchange-list' %}"><i class="icon-diaperchange" aria-hidden="true"></i>
-    {% trans "Changes" %}
-</a>
-{% endif %}
-{% if perms.core.add_diaperchange %}
-<a class="dropdown-item ps-5{% if request.path == '/changes/add/' %} active{% endif %}"
-   href="{% url 'core:diaperchange-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Change" %}
-</a>
-{% endif %}
-{% if perms.core.view_feeding %}
-<a class="dropdown-item{% if request.path == '/feedings/' %} active{% endif %}"
-   href="{% url 'core:feeding-list' %}"><i class="icon-feeding" aria-hidden="true"></i>
-{% trans "Feedings" %}
-</a>
-{% endif %}
-{% if perms.core.add_feeding %}
-<a class="dropdown-item ps-5{% if request.path == '/feedings/add/' %} active{% endif %}"
-   href="{% url 'core:feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Feeding" %}
-</a>
-{% endif %}
-{% if perms.core.add_feeding %}
-<a class="dropdown-item ps-5{% if request.path == '/feedings/bottle/add/' %} active{% endif %}"
-   href="{% url 'core:bottle-feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Bottle Feeding" %}
-</a>
-{% endif %}
-{% if perms.core.view_medication %}
-<a class="dropdown-item{% if request.path == '/medication/' %} active{% endif %}"
-   href="{% url 'core:medication-list' %}"><i class="icon-medication" aria-hidden="true"></i>
-{% trans "Medication" %}
-</a>
-{% endif %}
-{% if perms.core.add_medication %}
-<a class="dropdown-item ps-5{% if request.path == '/medication/add/' %} active{% endif %}"
-   href="{% url 'core:medication-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Medication" %}
-</a>
-{% endif %}
-{% if perms.core.view_pumping %}
-    <a class="dropdown-item{% if request.path == '/pumping/' %} active{% endif %}"
-       href="{% url 'core:pumping-list' %}">
-        <i class="icon-pumping" aria-hidden="true"></i>
-        {% trans "Pumping" %}
-    </a>
-{% endif %}
-{% if perms.core.add_pumping %}
-<a class="dropdown-item ps-5{% if request.path == '/pumping/add/' %} active{% endif %}"
-   href="{% url 'core:pumping-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Pumping entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_sleep %}
-<a class="dropdown-item{% if request.path == '/sleep/' %} active{% endif %}"
-   href="{% url 'core:sleep-list' %}"><i class="icon-sleep" aria-hidden="true"></i>
-{% trans "Sleep" %}
-</a>
-{% endif %}
-{% if perms.core.add_sleep %}
-<a class="dropdown-item ps-5{% if request.path == '/sleep/add/' %} active{% endif %}"
-   href="{% url 'core:sleep-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Sleep entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_tummytime %}
-<a class="dropdown-item{% if request.path == '/tummy-time/' %} active{% endif %}"
-   href="{% url 'core:tummytime-list' %}"><i class="icon-tummytime" aria-hidden="true"></i>
-{% trans "Tummy Time" %}
-</a>
-{% endif %}
-{% if perms.core.add_tummytime %}
-<a class="dropdown-item ps-5{% if request.path == '/tummy-time/add/' %} active{% endif %}"
-   href="{% url 'core:tummytime-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Tummy Time entry" %}
-</a>
-{% endif %}
-</div>
-</li>
-{% if perms.core.view_timer %}
-    {% timer_nav %}
-{% endif %}
-</ul>
-{% if request.user %}
-    <ul class="navbar-nav ms-auto">
-        <li class="nav-item dropdown">
-            <a id="nav-user-menu-link"
-               class="nav-link dropdown-toggle"
-               href="#"
-               data-bs-toggle="dropdown"
-               aria-haspopup="true"
-               aria-expanded="false">
-                <i class="icon-user" aria-hidden="true"></i>
-                {% firstof user.get_full_name user.get_username %}
-            </a>
-            <div class="dropdown-menu dropdown-menu-end"
-                 aria-labelledby="nav-user-menu-link">
-                <h6 class="dropdown-header">{% trans "User" %}</h6>
-                <a href="{% url 'babybuddy:user-settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
-                <a href="{% url 'babybuddy:user-password' %}" class="dropdown-item">{% trans "Password" %}</a>
-                <a href="{% url 'babybuddy:user-add-device' %}" class="dropdown-item">{% trans "Add a device" %}</a>
-                <form action="{% url 'babybuddy:logout' %}" role="form" method="post">
-                    {% csrf_token %}
-                    <button class="dropdown-item">{% trans "Logout" %}</button>
-                </form>
-                <h6 class="dropdown-header">{% trans "Site" %}</h6>
-                <a href="{% url 'api:api-root' %}" class="dropdown-item">{% trans "API Browser" %}</a>
-                {% if request.user.is_staff %}
-                    <a href="{% url 'babybuddy:site_settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
-                    <a href="{% url 'core:tag-list' %}" class="dropdown-item">{% trans "Tags" %}</a>
-                    <a href="{% url 'babybuddy:user-list' %}" class="dropdown-item">{% trans "Users" %}</a>
-                    <a href="{% url 'admin:index' %}" class="dropdown-item">{% trans "Database Admin" %}</a>
-                {% endif %}
-                <h6 class="dropdown-header">{% trans "Support" %}</h6>
-                <a href="https://github.com/babybuddy/babybuddy" class="dropdown-item">
-                    <i class="icon-source" aria-hidden="true"></i> {% trans "Source Code" %}</a>
-                <a href="https://gitter.im/babybuddy/Lobby" class="dropdown-item">
-                    <i class="icon-chat" aria-hidden="true"></i> {% trans "Chat / Support" %}</a>
-                <h6 class="dropdown-header">v{% version_string %}</h6>
+                    <a class="text-body-secondary"
+                       href="{% url 'dashboard:dashboard' %}"
+                       aria-expanded="false"><i class="icon-2x icon-dashboard" aria-hidden="true"></i>
+                    </a>
+                    &nbsp;
+                </div>
+                <div>
+                    <a class="text-body-secondary"
+                       href="{% url 'core:timeline' %}"
+                       aria-expanded="false"><i class="icon-2x icon-timeline" aria-hidden="true"></i>
+                    </a>
+                    &nbsp;
+                </div>
             </div>
-        </li>
-    </ul>
-{% endif %}
-</div>
-</div>
-</nav>
+            <div class="d-lg-none d-md-none d-flex ms-auto p-0 me-2">
+                {% quick_timer_nav %}
+                <div class="dropdown show">
+                    <a class="text-success"
+                       href="#"
+                       role="button"
+                       id="nav-quick-add-link"
+                       data-bs-toggle="dropdown"
+                       aria-haspopup="true"
+                       aria-expanded="false"><i class="icon-2x icon-add" aria-hidden="true"></i>
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-end"
+                         aria-labelledby="nav-quick-add-link">
+                        {% if perms.core.add_diaperchange %}
+                            <a class="dropdown-item p-2" href="{% url 'core:diaperchange-add' %}">
+                                <i class="icon-diaperchange" aria-hidden="true"></i>
+                                {% trans "Diaper Change" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_feeding %}
+                            <a class="dropdown-item p-2" href="{% url 'core:feeding-add' %}">
+                                <i class="icon-feeding" aria-hidden="true"></i>
+                                {% trans "Feeding" %}
+                            </a>
+                            <a class="dropdown-item p-2" href="{% url 'core:bottle-feeding-add' %}">
+                                <i class="icon-feeding" aria-hidden="true"></i>
+                                {% trans "Bottle Feeding" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_medication %}
+                            <a class="dropdown-item p-2" href="{% url 'core:medication-add' %}">
+                                <i class="icon-medication" aria-hidden="true"></i>
+                                {% trans "Medication" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_pumping %}
+                            <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
+                                <i class="icon-pumping" aria-hidden="true"></i>
+                                {% trans "Pumping" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_note %}
+                            <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
+                                <i class="icon-note" aria-hidden="true"></i>
+                                {% trans "Note" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_sleep %}
+                            <a class="dropdown-item p-2" href="{% url 'core:sleep-add' %}">
+                                <i class="icon-sleep" aria-hidden="true"></i>
+                                {% trans "Sleep" %}
+                            </a>
+                        {% endif %}
+                        {% if  perms.core.add_tummytime %}
+                            <a class="dropdown-item p-2" href="{% url 'core:tummytime-add' %}">
+                                <i class="icon-tummytime" aria-hidden="true"></i>
+                                {% trans "Tummy Time" %}
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <button class="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbar-app"
+                    aria-controls="navbar-app"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbar-app">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item{% if request.path == '/' %} active{% endif %}">
+                        <a class="nav-link" href="{% url 'dashboard:dashboard' %}">
+                            <i class="icon-dashboard" aria-hidden="true"></i>
+                            {% trans "Dashboard" %}
+                        </a>
+                    </li>
+                    <li class="nav-item{% if request.path == '/timeline' %} active{% endif %}">
+                        <a class="nav-link" href="{% url 'core:timeline' %}">
+                            <i class="icon-timeline" aria-hidden="true"></i>
+                            {% trans "Timeline" %}
+                        </a>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-children-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-child" aria-hidden="true"></i>
+                            {% trans "Children" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-children-menu-link">
+                            {% if perms.core.view_child %}
+                                <a class="dropdown-item{% if request.path == '/children/' %} active{% endif %}"
+                                   href="{% url 'core:child-list' %}">
+                                    <i class="icon-child" aria-hidden="true"></i>
+                                    {% trans "Children" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_child %}
+                                <a class="dropdown-item ps-5{% if request.path == '/children/add/' %} active{% endif %}"
+                                   href="{% url 'core:child-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Child" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_note %}
+                                <a class="dropdown-item{% if request.path == '/notes/' %} active{% endif %}"
+                                   href="{% url 'core:note-list' %}">
+                                    <i class="icon-note" aria-hidden="true"></i>
+                                    {% trans "Notes" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_note %}
+                                <a class="dropdown-item ps-5{% if request.path == '/notes/add/' %} active{% endif %}"
+                                   href="{% url 'core:note-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Note" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-measurements-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-measurements" aria-hidden="true"></i>
+                            {% trans "Measurements" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-measurements-menu-link">
+                            {% if perms.core.view_bmi %}
+                                <a class="dropdown-item{% if request.path == '/bmi/' %} active{% endif %}"
+                                   href="{% url 'core:bmi-list' %}">
+                                    <i class="icon-bmi" aria-hidden="true"></i>
+                                    {% trans "BMI" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_bmi %}
+                                <a class="dropdown-item ps-5{% if request.path == '/bmi/add/' %} active{% endif %}"
+                                   href="{% url 'core:bmi-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "BMI entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_head_circumference %}
+                                <a class="dropdown-item{% if request.path == '/head-circumference/' %} active{% endif %}"
+                                   href="{% url 'core:head-circumference-list' %}">
+                                    <i class="icon-head-circumference" aria-hidden="true"></i>
+                                    {% trans "Head Circumference" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_head_circumference %}
+                                <a class="dropdown-item ps-5{% if request.path == '/head-circumference/add/' %} active{% endif %}"
+                                   href="{% url 'core:head-circumference-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Head Circumference entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_height %}
+                                <a class="dropdown-item{% if request.path == '/height/' %} active{% endif %}"
+                                   href="{% url 'core:height-list' %}">
+                                    <i class="icon-height" aria-hidden="true"></i>
+                                    {% trans "Height" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_height %}
+                                <a class="dropdown-item ps-5{% if request.path == '/height/add/' %} active{% endif %}"
+                                   href="{% url 'core:height-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Height entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_temperature %}
+                                <a class="dropdown-item{% if request.path == '/temperature/' %} active{% endif %}"
+                                   href="{% url 'core:temperature-list' %}">
+                                    <i class="icon-temperature" aria-hidden="true"></i>
+                                    {% trans "Temperature" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_temperature %}
+                                <a class="dropdown-item ps-5{% if request.path == '/temperature/add/' %} active{% endif %}"
+                                   href="{% url 'core:temperature-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Temperature reading" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_weight %}
+                                <a class="dropdown-item{% if request.path == '/weight/' %} active{% endif %}"
+                                   href="{% url 'core:weight-list' %}">
+                                    <i class="icon-weight" aria-hidden="true"></i>
+                                    {% trans "Weight" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_weight %}
+                                <a class="dropdown-item ps-5{% if request.path == '/weight/add/' %} active{% endif %}"
+                                   href="{% url 'core:weight-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Weight entry" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-activity-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-activities" aria-hidden="true"></i>
+                            {% trans "Activities" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-activity-menu-link">
+                            {% if perms.core.view_diaperchange %}
+                                <a class="dropdown-item{% if request.path == '/changes/' %} active{% endif %}"
+                                   href="{% url 'core:diaperchange-list' %}"><i class="icon-diaperchange" aria-hidden="true"></i>
+                                    {% trans "Changes" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_diaperchange %}
+                                <a class="dropdown-item ps-5{% if request.path == '/changes/add/' %} active{% endif %}"
+                                   href="{% url 'core:diaperchange-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Change" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_feeding %}
+                                <a class="dropdown-item{% if request.path == '/feedings/' %} active{% endif %}"
+                                   href="{% url 'core:feeding-list' %}"><i class="icon-feeding" aria-hidden="true"></i>
+                                    {% trans "Feedings" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_feeding %}
+                                <a class="dropdown-item ps-5{% if request.path == '/feedings/add/' %} active{% endif %}"
+                                   href="{% url 'core:feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Feeding" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_feeding %}
+                                <a class="dropdown-item ps-5{% if request.path == '/feedings/bottle/add/' %} active{% endif %}"
+                                   href="{% url 'core:bottle-feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Bottle Feeding" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_medication %}
+                                <a class="dropdown-item{% if request.path == '/medication/' %} active{% endif %}"
+                                   href="{% url 'core:medication-list' %}"><i class="icon-medication" aria-hidden="true"></i>
+                                    {% trans "Medication" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_medication %}
+                                <a class="dropdown-item ps-5{% if request.path == '/medication/add/' %} active{% endif %}"
+                                   href="{% url 'core:medication-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Medication" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_pumping %}
+                                <a class="dropdown-item{% if request.path == '/pumping/' %} active{% endif %}"
+                                   href="{% url 'core:pumping-list' %}">
+                                    <i class="icon-pumping" aria-hidden="true"></i>
+                                    {% trans "Pumping" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_pumping %}
+                                <a class="dropdown-item ps-5{% if request.path == '/pumping/add/' %} active{% endif %}"
+                                   href="{% url 'core:pumping-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Pumping entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_sleep %}
+                                <a class="dropdown-item{% if request.path == '/sleep/' %} active{% endif %}"
+                                   href="{% url 'core:sleep-list' %}"><i class="icon-sleep" aria-hidden="true"></i>
+                                    {% trans "Sleep" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_sleep %}
+                                <a class="dropdown-item ps-5{% if request.path == '/sleep/add/' %} active{% endif %}"
+                                   href="{% url 'core:sleep-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Sleep entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_tummytime %}
+                                <a class="dropdown-item{% if request.path == '/tummy-time/' %} active{% endif %}"
+                                   href="{% url 'core:tummytime-list' %}"><i class="icon-tummytime" aria-hidden="true"></i>
+                                    {% trans "Tummy Time" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_tummytime %}
+                                <a class="dropdown-item ps-5{% if request.path == '/tummy-time/add/' %} active{% endif %}"
+                                   href="{% url 'core:tummytime-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Tummy Time entry" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    {% if perms.core.view_timer %}
+                        {% timer_nav %}
+                    {% endif %}
+                </ul>
+                {% if request.user %}
+                    <ul class="navbar-nav ms-auto">
+                        <li class="nav-item dropdown">
+                            <a id="nav-user-menu-link"
+                               class="nav-link dropdown-toggle"
+                               href="#"
+                               data-bs-toggle="dropdown"
+                               aria-haspopup="true"
+                               aria-expanded="false">
+                                <i class="icon-user" aria-hidden="true"></i>
+                                {% firstof user.get_full_name user.get_username %}
+                            </a>
+                            <div class="dropdown-menu dropdown-menu-end"
+                                 aria-labelledby="nav-user-menu-link">
+                                <h6 class="dropdown-header">{% trans "User" %}</h6>
+                                <a href="{% url 'babybuddy:user-settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
+                                <a href="{% url 'babybuddy:user-password' %}" class="dropdown-item">{% trans "Password" %}</a>
+                                <a href="{% url 'babybuddy:user-add-device' %}" class="dropdown-item">{% trans "Add a device" %}</a>
+                                <form action="{% url 'babybuddy:logout' %}" role="form" method="post">
+                                    {% csrf_token %}
+                                    <button class="dropdown-item">{% trans "Logout" %}</button>
+                                </form>
+                                <h6 class="dropdown-header">{% trans "Site" %}</h6>
+                                <a href="{% url 'api:api-root' %}" class="dropdown-item">{% trans "API Browser" %}</a>
+                                {% if request.user.is_staff %}
+                                    <a href="{% url 'babybuddy:site_settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
+                                    <a href="{% url 'core:tag-list' %}" class="dropdown-item">{% trans "Tags" %}</a>
+                                    <a href="{% url 'babybuddy:user-list' %}" class="dropdown-item">{% trans "Users" %}</a>
+                                    <a href="{% url 'admin:index' %}" class="dropdown-item">{% trans "Database Admin" %}</a>
+                                {% endif %}
+                                <h6 class="dropdown-header">{% trans "Support" %}</h6>
+                                <a href="https://github.com/babybuddy/babybuddy" class="dropdown-item">
+                                    <i class="icon-source" aria-hidden="true"></i> {% trans "Source Code" %}</a>
+                                <a href="https://gitter.im/babybuddy/Lobby" class="dropdown-item">
+                                    <i class="icon-chat" aria-hidden="true"></i> {% trans "Chat / Support" %}</a>
+                                <h6 class="dropdown-header">v{% version_string %}</h6>
+                            </div>
+                        </li>
+                    </ul>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
 {% endblock %}

--- a/core/templates/core/quick_timer_nav.html
+++ b/core/templates/core/quick_timer_nav.html
@@ -6,33 +6,33 @@
     {% csrf_token %}
     {% if children.count > 1 %}
         <div class="dropdown show">
-        <a class="m-0 p-0 text-success"
-           title="{% trans "Quick Start Timer" %}"
-           href="#"
-           role="button"
-           id="quick-timer-menu-toggle"
-           data-bs-toggle="dropdown"
-           aria-haspopup="true"
-           aria-expanded="false"><i class="icon-2x icon-timer" aria-hidden="true"></i>
-    </a>
-    <div class="dropdown-menu dropdown-menu-end"
-         aria-labelledby="quick-timer-menu-toggle">
-        <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
-        {% for child in children %}
-            <button class="dropdown-item d-flex align-items-center"
-                    type="submit"
-                    name="child"
-                    value="{{ child.pk }}">
-                {% include "core/child_thumbnail.html" %}
-                <span class="text-wrap ms-2">{{ child }}</span>
-            </button>
-        {% endfor %}
-    </div>
-</div>
-{% else %}
-<label class="visually-hidden">{% trans "Quick Start Timer" %}</label>
-<button class="btn m-0 p-0 text-success">
-    <i class="icon-2x icon-timer" aria-hidden="true"></i>
-</button>
-{% endif %}
+            <a class="m-0 p-0 text-success"
+               title="{% trans "Quick Start Timer" %}"
+               href="#"
+               role="button"
+               id="quick-timer-menu-toggle"
+               data-bs-toggle="dropdown"
+               aria-haspopup="true"
+               aria-expanded="false"><i class="icon-2x icon-timer" aria-hidden="true"></i>
+            </a>
+            <div class="dropdown-menu dropdown-menu-end"
+                 aria-labelledby="quick-timer-menu-toggle">
+                <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
+                {% for child in children %}
+                    <button class="dropdown-item d-flex align-items-center"
+                            type="submit"
+                            name="child"
+                            value="{{ child.pk }}">
+                        {% include "core/child_thumbnail.html" %}
+                        <span class="text-wrap ms-2">{{ child }}</span>
+                    </button>
+                {% endfor %}
+            </div>
+        </div>
+    {% else %}
+        <label class="visually-hidden">{% trans "Quick Start Timer" %}</label>
+        <button class="btn m-0 p-0 text-success">
+            <i class="icon-2x icon-timer" aria-hidden="true"></i>
+        </button>
+    {% endif %}
 </form>

--- a/core/templates/core/sleep_list.html
+++ b/core/templates/core/sleep_list.html
@@ -62,7 +62,7 @@
                             <td>{{ sleep.duration|duration_string }}</td>
                             <td>
                                 {% if prev_sleep %}
-                                    {% blocktrans trimmed with time_ago=prev_sleep.start|timesince:sleep.start %}
+                                    {% blocktrans trimmed with time_ago=prev_sleep.end|timesince:sleep.start %}
                                         {{ time_ago }} ago
                                     {% endblocktrans %}
                                 {% endif %}

--- a/core/templates/core/timer_detail.html
+++ b/core/templates/core/timer_detail.html
@@ -25,60 +25,60 @@
             </p>
             <div class="d-grid gap-4 mb-4">
                 {% if perms.core.add_feeding %}
-                <a class="btn btn-success btn-lg"
-                   href="{% instance_add_url 'core:feeding-add' %}"
-                   role="button"><i class="icon-feeding" aria-hidden="true"></i>
-                {% trans "Feeding" %}
-            </a>
-        {% endif %}
-        {% if perms.core.add_pumping %}
-        <a class="btn btn-success btn-lg"
-           href="{% instance_add_url 'core:pumping-add' %}"
-           role="button"><i class="icon-pumping" aria-hidden="true"></i>
-        {% trans "Pumping" %}
-    </a>
-{% endif %}
-{% if perms.core.add_sleep %}
-<a class="btn btn-success btn-lg"
-   href="{% instance_add_url 'core:sleep-add' %}"
-   role="button"><i class="icon-sleep" aria-hidden="true"></i>
-{% trans "Sleep" %}
-</a>
-{% endif %}
-{% if perms.core.add_tummytime %}
-<a class="btn btn-success btn-lg"
-   href="{% instance_add_url 'core:tummytime-add' %}"
-   role="button"><i class="icon-tummytime" aria-hidden="true"></i>
-{% trans "Tummy Time" %}
-</a>
-{% endif %}
-</div>
-<div class="center-block"
-     role="group"
-     aria-label="{% trans "Timer actions" %}">
-    {% if perms.core.delete_timer %}
-        <a class="btn btn-lg btn-danger"
-           href="{% url 'core:timer-delete' timer.id %}"
-           role="button"><i class="icon-delete" aria-hidden="true"></i></a>
-    {% endif %}
-    {% if perms.core.change_timer %}
-        <a class="btn btn-lg btn-primary"
-           href="{% url 'core:timer-update' timer.id %}"
-           role="button"><i class="icon-update" aria-hidden="true"></i></a>
-        <form action="{% url 'core:timer-restart' timer.id %}"
-              role="form"
-              method="post"
-              class="d-inline">
-            {% csrf_token %}
-            <label class="visually-hidden">{% trans "Restart timer" %}</label>
-            <button type="submit" class="btn btn-lg btn-secondary">
-                <i class="icon-refresh" aria-hidden="true"></i>
-            </button>
-        </form>
-    {% endif %}
-</div>
-</div>
-</div>
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:feeding-add' %}"
+                       role="button"><i class="icon-feeding" aria-hidden="true"></i>
+                        {% trans "Feeding" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_pumping %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:pumping-add' %}"
+                       role="button"><i class="icon-pumping" aria-hidden="true"></i>
+                        {% trans "Pumping" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_sleep %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:sleep-add' %}"
+                       role="button"><i class="icon-sleep" aria-hidden="true"></i>
+                        {% trans "Sleep" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_tummytime %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:tummytime-add' %}"
+                       role="button"><i class="icon-tummytime" aria-hidden="true"></i>
+                        {% trans "Tummy Time" %}
+                    </a>
+                {% endif %}
+            </div>
+            <div class="center-block"
+                 role="group"
+                 aria-label="{% trans "Timer actions" %}">
+                {% if perms.core.delete_timer %}
+                    <a class="btn btn-lg btn-danger"
+                       href="{% url 'core:timer-delete' timer.id %}"
+                       role="button"><i class="icon-delete" aria-hidden="true"></i></a>
+                {% endif %}
+                {% if perms.core.change_timer %}
+                    <a class="btn btn-lg btn-primary"
+                       href="{% url 'core:timer-update' timer.id %}"
+                       role="button"><i class="icon-update" aria-hidden="true"></i></a>
+                    <form action="{% url 'core:timer-restart' timer.id %}"
+                          role="form"
+                          method="post"
+                          class="d-inline">
+                        {% csrf_token %}
+                        <label class="visually-hidden">{% trans "Restart timer" %}</label>
+                        <button type="submit" class="btn btn-lg btn-secondary">
+                            <i class="icon-refresh" aria-hidden="true"></i>
+                        </button>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
 {% endblock %}
 {% block javascript %}
     <script type="application/javascript">BabyBuddy.Timer.run({{ timer.id }}, 'timer-status');</script>

--- a/core/templates/core/timer_nav.html
+++ b/core/templates/core/timer_nav.html
@@ -1,57 +1,57 @@
 {% load i18n %}
 <li class="nav-item dropdown">
-<a id="nav-timer-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-timer" aria-hidden="true"></i>
-{% trans "Timers" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-timer-menu-link">
-    {% if perms.core.add_timer %}
-        <a class="dropdown-item" href="{% url 'core:timer-add' %}">
-            <i class="icon-add" aria-hidden="true"></i> {% trans "Start Timer" %}
-        </a>
-    {% endif %}
-    {% if perms.core.view_timer %}
-        <a class="dropdown-item" href="{% url 'core:timer-list' %}">
-            <i class="icon-list" aria-hidden="true"></i> {% trans "View Timers" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_timer %}
-        <form action="{% url 'core:timer-add-quick' %}"
-              role="form"
-              method="post"
-              class="d-inline">
-            {% csrf_token %}
-            {% if children.count > 1 %}
-                <div class="dropdown-divider"></div>
-                <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
-                {% for child in children %}
-                    <button class="dropdown-item d-flex align-items-center"
-                            type="submit"
-                            name="child"
-                            value="{{ child.pk }}">
-                        {% include "core/child_thumbnail.html" %}
-                        <span class="text-wrap ms-2">{{ child }}</span>
+    <a id="nav-timer-menu-link"
+       class="nav-link dropdown-toggle"
+       href="#"
+       data-bs-toggle="dropdown"
+       aria-haspopup="true"
+       aria-expanded="false"><i class="icon-timer" aria-hidden="true"></i>
+        {% trans "Timers" %}
+    </a>
+    <div class="dropdown-menu" aria-labelledby="nav-timer-menu-link">
+        {% if perms.core.add_timer %}
+            <a class="dropdown-item" href="{% url 'core:timer-add' %}">
+                <i class="icon-add" aria-hidden="true"></i> {% trans "Start Timer" %}
+            </a>
+        {% endif %}
+        {% if perms.core.view_timer %}
+            <a class="dropdown-item" href="{% url 'core:timer-list' %}">
+                <i class="icon-list" aria-hidden="true"></i> {% trans "View Timers" %}
+            </a>
+        {% endif %}
+        {% if perms.core.add_timer %}
+            <form action="{% url 'core:timer-add-quick' %}"
+                  role="form"
+                  method="post"
+                  class="d-inline">
+                {% csrf_token %}
+                {% if children.count > 1 %}
+                    <div class="dropdown-divider"></div>
+                    <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
+                    {% for child in children %}
+                        <button class="dropdown-item d-flex align-items-center"
+                                type="submit"
+                                name="child"
+                                value="{{ child.pk }}">
+                            {% include "core/child_thumbnail.html" %}
+                            <span class="text-wrap ms-2">{{ child }}</span>
+                        </button>
+                    {% endfor %}
+                {% else %}
+                    <button class="dropdown-item" type="submit">
+                        <i class="icon-timer" aria-hidden="true"></i> {% trans "Quick Start Timer" %}
                     </button>
-                {% endfor %}
-            {% else %}
-                <button class="dropdown-item" type="submit">
-                    <i class="icon-timer" aria-hidden="true"></i> {% trans "Quick Start Timer" %}
-                </button>
-            {% endif %}
-        </form>
-    {% endif %}
-    {% if timers %}
-        <div class="dropdown-divider"></div>
-        <h6 class="dropdown-header">{% trans "Timers" %}</h6>
-        {% for timer in timers %}
-            <a class="dropdown-item" href="{% url 'core:timer-detail' timer.id %}">{{ timer.title_with_child }}</a>
-        {% empty %}
-            <a class="dropdown-item disabled" href="#">{% trans "None" %}</a>
-        {% endfor %}
-    {% endif %}
-</div>
+                {% endif %}
+            </form>
+        {% endif %}
+        {% if timers %}
+            <div class="dropdown-divider"></div>
+            <h6 class="dropdown-header">{% trans "Timers" %}</h6>
+            {% for timer in timers %}
+                <a class="dropdown-item" href="{% url 'core:timer-detail' timer.id %}">{{ timer.title_with_child }}</a>
+            {% empty %}
+                <a class="dropdown-item disabled" href="#">{% trans "None" %}</a>
+            {% endfor %}
+        {% endif %}
+    </div>
 </li>

--- a/core/timeline.py
+++ b/core/timeline.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from django.urls import reverse
 from django.utils import timezone, timesince
 from django.utils.translation import gettext as _
+from django.db.models import Q
 
 from core.models import (
     DiaperChange,
@@ -15,6 +16,21 @@ from core.models import (
     Medication,
 )
 from core.utils import duration_string
+
+
+def _is_in_range(value, min_date, max_date):
+    return min_date <= value <= max_date
+
+
+def _duration_instances_for_day(model, min_date, max_date, child=None):
+    instances = model.objects.filter(
+        Q(start__range=(min_date, max_date)) | Q(end__range=(min_date, max_date))
+    ).distinct()
+
+    if child:
+        instances = instances.filter(child=child)
+
+    return instances.order_by("-start")
 
 
 def get_objects(date, child=None):
@@ -49,81 +65,98 @@ def get_objects(date, child=None):
 
 
 def _add_tummy_times(min_date, max_date, events, child=None):
-    instances = TummyTime.objects.filter(start__range=(min_date, max_date)).order_by(
-        "-start"
+    instances = _duration_instances_for_day(
+        TummyTime,
+        min_date,
+        max_date,
+        child,
     )
-    if child:
-        instances = instances.filter(child=child)
+
     for instance in instances:
         details = []
+
         if instance.milestone:
             details.append(instance.milestone)
+
         edit_link = reverse("core:tummytime-update", args=[instance.id])
-        events.append(
-            {
-                "time": timezone.localtime(instance.start),
-                "event": _("%(child)s started tummy time!")
+
+        if _is_in_range(instance.start, min_date, max_date):
+            events.append(
+                {
+                    "time": timezone.localtime(instance.start),
+                    "event": _("%(child)s started tummy time!")
+                    % {"child": instance.child.first_name},
+                    "details": details,
+                    "edit_link": edit_link,
+                    "model_name": instance.model_name,
+                    "type": "start",
+                    "tags": instance.tags.all(),
+                }
+            )
+
+        if _is_in_range(instance.end, min_date, max_date):
+            end = {
+                "time": timezone.localtime(instance.end),
+                "event": _("%(child)s finished tummy time.")
                 % {"child": instance.child.first_name},
                 "details": details,
                 "edit_link": edit_link,
                 "model_name": instance.model_name,
-                "type": "start",
+                "type": "end",
                 "tags": instance.tags.all(),
             }
-        )
 
-        end = {
-            "time": timezone.localtime(instance.end),
-            "event": _("%(child)s finished tummy time.")
-            % {"child": instance.child.first_name},
-            "details": details,
-            "edit_link": edit_link,
-            "model_name": instance.model_name,
-            "type": "end",
-            "tags": instance.tags.all(),
-        }
-        if instance.duration > timedelta(seconds=0):
-            end["duration"] = duration_string(instance.duration)
+            if instance.duration > timedelta(seconds=0):
+                end["duration"] = duration_string(instance.duration)
 
-        events.append(end)
+            events.append(end)
 
 
 def _add_sleeps(min_date, max_date, events, child=None):
-    instances = Sleep.objects.filter(start__range=(min_date, max_date)).order_by(
-        "-start"
+    instances = _duration_instances_for_day(
+        Sleep,
+        min_date,
+        max_date,
+        child,
     )
-    if child:
-        instances = instances.filter(child=child)
+
     for instance in instances:
         details = []
+
         if instance.notes:
             details.append(instance.notes)
+
         edit_link = reverse("core:sleep-update", args=[instance.id])
-        events.append(
-            {
-                "time": timezone.localtime(instance.start),
-                "event": _("%(child)s fell asleep.")
-                % {"child": instance.child.first_name},
+
+        if _is_in_range(instance.start, min_date, max_date):
+            events.append(
+                {
+                    "time": timezone.localtime(instance.start),
+                    "event": _("%(child)s fell asleep.")
+                    % {"child": instance.child.first_name},
+                    "details": details,
+                    "edit_link": edit_link,
+                    "model_name": instance.model_name,
+                    "type": "start",
+                    "tags": instance.tags.all(),
+                }
+            )
+
+        if _is_in_range(instance.end, min_date, max_date):
+            end = {
+                "time": timezone.localtime(instance.end),
+                "event": _("%(child)s woke up.") % {"child": instance.child.first_name},
                 "details": details,
                 "edit_link": edit_link,
                 "model_name": instance.model_name,
-                "type": "start",
+                "type": "end",
                 "tags": instance.tags.all(),
             }
-        )
 
-        end = {
-            "time": timezone.localtime(instance.end),
-            "event": _("%(child)s woke up.") % {"child": instance.child.first_name},
-            "details": details,
-            "edit_link": edit_link,
-            "model_name": instance.model_name,
-            "type": "end",
-            "tags": instance.tags.all(),
-        }
-        if instance.duration > timedelta(seconds=0):
-            end["duration"] = duration_string(instance.duration)
-        events.append(end)
+            if instance.duration > timedelta(seconds=0):
+                end["duration"] = duration_string(instance.duration)
+
+            events.append(end)
 
 
 def _add_feedings(min_date, max_date, events, child=None):
@@ -131,22 +164,41 @@ def _add_feedings(min_date, max_date, events, child=None):
     yesterday = min_date - timedelta(days=1)
     prev_start = None
 
-    instances = Feeding.objects.filter(start__range=(yesterday, max_date)).order_by(
-        "start"
+    instances = (
+        Feeding.objects.filter(
+            Q(start__range=(yesterday, max_date)) | Q(end__range=(min_date, max_date))
+        )
+        .distinct()
+        .order_by("start")
     )
+
     if child:
         instances = instances.filter(child=child)
+
     for instance in instances:
         details = []
+
         if instance.notes:
             details.append(instance.notes)
+
         time_since_prev = None
+
         if prev_start:
-            time_since_prev = timesince.timesince(prev_start, now=instance.start)
+            time_since_prev = timesince.timesince(
+                prev_start,
+                now=instance.start,
+            )
+
         prev_start = instance.start
-        if instance.start < min_date:
+
+        if instance.start < min_date and not min_date <= instance.end <= max_date:
             continue
-        edit_link = reverse("core:feeding-update", args=[instance.id])
+
+        edit_link = reverse(
+            "core:feeding-update",
+            args=[instance.id],
+        )
+
         if instance.amount:
             details.append(_("Amount") + ": " + str(instance.amount))
 
@@ -159,32 +211,39 @@ def _add_feedings(min_date, max_date, events, child=None):
         }
 
         if instance.duration > timedelta(seconds=0):
-            start_event = {
-                **base_object,
-                "event": _("%(child)s started feeding.")
-                % {"child": instance.child.first_name},
-                "time_since_prev": time_since_prev,
-                "type": "start",
-            }
+            if min_date <= instance.start <= max_date:
+                start_event = {
+                    **base_object,
+                    "event": _("%(child)s started feeding.")
+                    % {"child": instance.child.first_name},
+                    "time_since_prev": time_since_prev,
+                    "type": "start",
+                }
 
-            end_event = {
-                **base_object,
-                "time": timezone.localtime(instance.end),
-                "event": _("%(child)s finished feeding.")
-                % {"child": instance.child.first_name},
-                "type": "end",
-                "duration": duration_string(instance.duration),
-            }
+                events.append(start_event)
 
-            events.extend([start_event, end_event])
+            if min_date <= instance.end <= max_date:
+                end_event = {
+                    **base_object,
+                    "time": timezone.localtime(instance.end),
+                    "event": _("%(child)s finished feeding.")
+                    % {"child": instance.child.first_name},
+                    "type": "end",
+                    "duration": duration_string(instance.duration),
+                }
+
+                events.append(end_event)
+
         else:
-            feed_event = {
-                **base_object,
-                "event": _("%(child)s had a feeding.")
-                % {"child": instance.child.first_name},
-                "time_since_prev": time_since_prev,
-            }
-            events.append(feed_event)
+            if min_date <= instance.start <= max_date:
+                feed_event = {
+                    **base_object,
+                    "event": _("%(child)s had a feeding.")
+                    % {"child": instance.child.first_name},
+                    "time_since_prev": time_since_prev,
+                }
+
+                events.append(feed_event)
 
 
 def _add_diaper_changes(min_date, max_date, events, child):


### PR DESCRIPTION
## Summary

Fixes timeline display for sleep, feeding, and tummy time entries that span midnight.

Previously, both the start and end events were shown on the day the activity started. This change:

- selects duration-based entries when either the start or end falls within the requested day;
- displays each timeline event only on the day matching its timestamp;
- preserves feeding time-since-previous behavior.

## Testing

- Ran `black` on `core/timeline.py`
- Ran `python manage.py check`
- Manually verified entries spanning midnight

Fixes #942 