### PR TITLE
feat: notify user and disable actions when timer is ended in another session

### DIFF
--- a/babybuddy/templates/babybuddy/nav-dropdown.html
+++ b/babybuddy/templates/babybuddy/nav-dropdown.html
@@ -15,356 +15,356 @@
             </a>
             <div class="d-lg-none d-md-none d-flex me-auto p-0 ms-2">
                 <div>
-                <a class="text-body-secondary"
-                   href="{% url 'dashboard:dashboard' %}"
-                   aria-expanded="false"><i class="icon-2x icon-dashboard" aria-hidden="true"></i>
-            </a>
-            &nbsp;
-        </div>
-        <div>
-        <a class="text-body-secondary"
-           href="{% url 'core:timeline' %}"
-           aria-expanded="false"><i class="icon-2x icon-timeline" aria-hidden="true"></i>
-    </a>
-    &nbsp;
-</div>
-</div>
-<div class="d-lg-none d-md-none d-flex ms-auto p-0 me-2">
-    {% quick_timer_nav %}
-    <div class="dropdown show">
-    <a class="text-success"
-       href="#"
-       role="button"
-       id="nav-quick-add-link"
-       data-bs-toggle="dropdown"
-       aria-haspopup="true"
-       aria-expanded="false"><i class="icon-2x icon-add" aria-hidden="true"></i>
-</a>
-<div class="dropdown-menu dropdown-menu-end"
-     aria-labelledby="nav-quick-add-link">
-    {% if perms.core.add_diaperchange %}
-        <a class="dropdown-item p-2" href="{% url 'core:diaperchange-add' %}">
-            <i class="icon-diaperchange" aria-hidden="true"></i>
-            {% trans "Diaper Change" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_feeding %}
-        <a class="dropdown-item p-2" href="{% url 'core:feeding-add' %}">
-            <i class="icon-feeding" aria-hidden="true"></i>
-            {% trans "Feeding" %}
-        </a>
-        <a class="dropdown-item p-2" href="{% url 'core:bottle-feeding-add' %}">
-            <i class="icon-feeding" aria-hidden="true"></i>
-            {% trans "Bottle Feeding" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_medication %}
-        <a class="dropdown-item p-2" href="{% url 'core:medication-add' %}">
-            <i class="icon-medication" aria-hidden="true"></i>
-            {% trans "Medication" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_pumping %}
-        <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
-            <i class="icon-pumping" aria-hidden="true"></i>
-            {% trans "Pumping" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_note %}
-        <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
-            <i class="icon-note" aria-hidden="true"></i>
-            {% trans "Note" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_sleep %}
-        <a class="dropdown-item p-2" href="{% url 'core:sleep-add' %}">
-            <i class="icon-sleep" aria-hidden="true"></i>
-            {% trans "Sleep" %}
-        </a>
-    {% endif %}
-    {% if  perms.core.add_tummytime %}
-        <a class="dropdown-item p-2" href="{% url 'core:tummytime-add' %}">
-            <i class="icon-tummytime" aria-hidden="true"></i>
-            {% trans "Tummy Time" %}
-        </a>
-    {% endif %}
-</div>
-</div>
-</div>
-<button class="navbar-toggler"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#navbar-app"
-        aria-controls="navbar-app"
-        aria-expanded="false"
-        aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-</button>
-<div class="collapse navbar-collapse" id="navbar-app">
-    <ul class="navbar-nav me-auto">
-        <li class="nav-item{% if request.path == '/' %} active{% endif %}">
-            <a class="nav-link" href="{% url 'dashboard:dashboard' %}">
-                <i class="icon-dashboard" aria-hidden="true"></i>
-                {% trans "Dashboard" %}
-            </a>
-        </li>
-        <li class="nav-item{% if request.path == '/timeline' %} active{% endif %}">
-            <a class="nav-link" href="{% url 'core:timeline' %}">
-                <i class="icon-timeline" aria-hidden="true"></i>
-                {% trans "Timeline" %}
-            </a>
-        </li>
-        <li class="nav-item dropdown">
-        <a id="nav-children-menu-link"
-           class="nav-link dropdown-toggle"
-           href="#"
-           data-bs-toggle="dropdown"
-           aria-haspopup="true"
-           aria-expanded="false"><i class="icon-child" aria-hidden="true"></i>
-        {% trans "Children" %}
-    </a>
-    <div class="dropdown-menu" aria-labelledby="nav-children-menu-link">
-        {% if perms.core.view_child %}
-            <a class="dropdown-item{% if request.path == '/children/' %} active{% endif %}"
-               href="{% url 'core:child-list' %}">
-                <i class="icon-child" aria-hidden="true"></i>
-                {% trans "Children" %}
-            </a>
-        {% endif %}
-        {% if perms.core.add_child %}
-        <a class="dropdown-item ps-5{% if request.path == '/children/add/' %} active{% endif %}"
-           href="{% url 'core:child-add' %}"><i class="icon-add" aria-hidden="true"></i>
-        {% trans "Child" %}
-    </a>
-{% endif %}
-{% if perms.core.view_note %}
-    <a class="dropdown-item{% if request.path == '/notes/' %} active{% endif %}"
-       href="{% url 'core:note-list' %}">
-        <i class="icon-note" aria-hidden="true"></i>
-        {% trans "Notes" %}
-    </a>
-{% endif %}
-{% if perms.core.add_note %}
-<a class="dropdown-item ps-5{% if request.path == '/notes/add/' %} active{% endif %}"
-   href="{% url 'core:note-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Note" %}
-</a>
-{% endif %}
-</div>
-</li>
-<li class="nav-item dropdown">
-<a id="nav-measurements-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-measurements" aria-hidden="true"></i>
-{% trans "Measurements" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-measurements-menu-link">
-    {% if perms.core.view_bmi %}
-        <a class="dropdown-item{% if request.path == '/bmi/' %} active{% endif %}"
-           href="{% url 'core:bmi-list' %}">
-            <i class="icon-bmi" aria-hidden="true"></i>
-            {% trans "BMI" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_bmi %}
-    <a class="dropdown-item ps-5{% if request.path == '/bmi/add/' %} active{% endif %}"
-       href="{% url 'core:bmi-add' %}"><i class="icon-add" aria-hidden="true"></i>
-    {% trans "BMI entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_head_circumference %}
-    <a class="dropdown-item{% if request.path == '/head-circumference/' %} active{% endif %}"
-       href="{% url 'core:head-circumference-list' %}">
-        <i class="icon-head-circumference" aria-hidden="true"></i>
-        {% trans "Head Circumference" %}
-    </a>
-{% endif %}
-{% if perms.core.add_head_circumference %}
-<a class="dropdown-item ps-5{% if request.path == '/head-circumference/add/' %} active{% endif %}"
-   href="{% url 'core:head-circumference-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Head Circumference entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_height %}
-    <a class="dropdown-item{% if request.path == '/height/' %} active{% endif %}"
-       href="{% url 'core:height-list' %}">
-        <i class="icon-height" aria-hidden="true"></i>
-        {% trans "Height" %}
-    </a>
-{% endif %}
-{% if perms.core.add_height %}
-<a class="dropdown-item ps-5{% if request.path == '/height/add/' %} active{% endif %}"
-   href="{% url 'core:height-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Height entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_temperature %}
-    <a class="dropdown-item{% if request.path == '/temperature/' %} active{% endif %}"
-       href="{% url 'core:temperature-list' %}">
-        <i class="icon-temperature" aria-hidden="true"></i>
-        {% trans "Temperature" %}
-    </a>
-{% endif %}
-{% if perms.core.add_temperature %}
-<a class="dropdown-item ps-5{% if request.path == '/temperature/add/' %} active{% endif %}"
-   href="{% url 'core:temperature-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Temperature reading" %}
-</a>
-{% endif %}
-{% if perms.core.view_weight %}
-    <a class="dropdown-item{% if request.path == '/weight/' %} active{% endif %}"
-       href="{% url 'core:weight-list' %}">
-        <i class="icon-weight" aria-hidden="true"></i>
-        {% trans "Weight" %}
-    </a>
-{% endif %}
-{% if perms.core.add_weight %}
-<a class="dropdown-item ps-5{% if request.path == '/weight/add/' %} active{% endif %}"
-   href="{% url 'core:weight-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Weight entry" %}
-</a>
-{% endif %}
-</div>
-</li>
-<li class="nav-item dropdown">
-<a id="nav-activity-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-activities" aria-hidden="true"></i>
-{% trans "Activities" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-activity-menu-link">
-    {% if perms.core.view_diaperchange %}
-    <a class="dropdown-item{% if request.path == '/changes/' %} active{% endif %}"
-       href="{% url 'core:diaperchange-list' %}"><i class="icon-diaperchange" aria-hidden="true"></i>
-    {% trans "Changes" %}
-</a>
-{% endif %}
-{% if perms.core.add_diaperchange %}
-<a class="dropdown-item ps-5{% if request.path == '/changes/add/' %} active{% endif %}"
-   href="{% url 'core:diaperchange-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Change" %}
-</a>
-{% endif %}
-{% if perms.core.view_feeding %}
-<a class="dropdown-item{% if request.path == '/feedings/' %} active{% endif %}"
-   href="{% url 'core:feeding-list' %}"><i class="icon-feeding" aria-hidden="true"></i>
-{% trans "Feedings" %}
-</a>
-{% endif %}
-{% if perms.core.add_feeding %}
-<a class="dropdown-item ps-5{% if request.path == '/feedings/add/' %} active{% endif %}"
-   href="{% url 'core:feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Feeding" %}
-</a>
-{% endif %}
-{% if perms.core.add_feeding %}
-<a class="dropdown-item ps-5{% if request.path == '/feedings/bottle/add/' %} active{% endif %}"
-   href="{% url 'core:bottle-feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Bottle Feeding" %}
-</a>
-{% endif %}
-{% if perms.core.view_medication %}
-<a class="dropdown-item{% if request.path == '/medication/' %} active{% endif %}"
-   href="{% url 'core:medication-list' %}"><i class="icon-medication" aria-hidden="true"></i>
-{% trans "Medication" %}
-</a>
-{% endif %}
-{% if perms.core.add_medication %}
-<a class="dropdown-item ps-5{% if request.path == '/medication/add/' %} active{% endif %}"
-   href="{% url 'core:medication-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Medication" %}
-</a>
-{% endif %}
-{% if perms.core.view_pumping %}
-    <a class="dropdown-item{% if request.path == '/pumping/' %} active{% endif %}"
-       href="{% url 'core:pumping-list' %}">
-        <i class="icon-pumping" aria-hidden="true"></i>
-        {% trans "Pumping" %}
-    </a>
-{% endif %}
-{% if perms.core.add_pumping %}
-<a class="dropdown-item ps-5{% if request.path == '/pumping/add/' %} active{% endif %}"
-   href="{% url 'core:pumping-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Pumping entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_sleep %}
-<a class="dropdown-item{% if request.path == '/sleep/' %} active{% endif %}"
-   href="{% url 'core:sleep-list' %}"><i class="icon-sleep" aria-hidden="true"></i>
-{% trans "Sleep" %}
-</a>
-{% endif %}
-{% if perms.core.add_sleep %}
-<a class="dropdown-item ps-5{% if request.path == '/sleep/add/' %} active{% endif %}"
-   href="{% url 'core:sleep-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Sleep entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_tummytime %}
-<a class="dropdown-item{% if request.path == '/tummy-time/' %} active{% endif %}"
-   href="{% url 'core:tummytime-list' %}"><i class="icon-tummytime" aria-hidden="true"></i>
-{% trans "Tummy Time" %}
-</a>
-{% endif %}
-{% if perms.core.add_tummytime %}
-<a class="dropdown-item ps-5{% if request.path == '/tummy-time/add/' %} active{% endif %}"
-   href="{% url 'core:tummytime-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Tummy Time entry" %}
-</a>
-{% endif %}
-</div>
-</li>
-{% if perms.core.view_timer %}
-    {% timer_nav %}
-{% endif %}
-</ul>
-{% if request.user %}
-    <ul class="navbar-nav ms-auto">
-        <li class="nav-item dropdown">
-            <a id="nav-user-menu-link"
-               class="nav-link dropdown-toggle"
-               href="#"
-               data-bs-toggle="dropdown"
-               aria-haspopup="true"
-               aria-expanded="false">
-                <i class="icon-user" aria-hidden="true"></i>
-                {% firstof user.get_full_name user.get_username %}
-            </a>
-            <div class="dropdown-menu dropdown-menu-end"
-                 aria-labelledby="nav-user-menu-link">
-                <h6 class="dropdown-header">{% trans "User" %}</h6>
-                <a href="{% url 'babybuddy:user-settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
-                <a href="{% url 'babybuddy:user-password' %}" class="dropdown-item">{% trans "Password" %}</a>
-                <a href="{% url 'babybuddy:user-add-device' %}" class="dropdown-item">{% trans "Add a device" %}</a>
-                <form action="{% url 'babybuddy:logout' %}" role="form" method="post">
-                    {% csrf_token %}
-                    <button class="dropdown-item">{% trans "Logout" %}</button>
-                </form>
-                <h6 class="dropdown-header">{% trans "Site" %}</h6>
-                <a href="{% url 'api:api-root' %}" class="dropdown-item">{% trans "API Browser" %}</a>
-                {% if request.user.is_staff %}
-                    <a href="{% url 'babybuddy:site_settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
-                    <a href="{% url 'core:tag-list' %}" class="dropdown-item">{% trans "Tags" %}</a>
-                    <a href="{% url 'babybuddy:user-list' %}" class="dropdown-item">{% trans "Users" %}</a>
-                    <a href="{% url 'admin:index' %}" class="dropdown-item">{% trans "Database Admin" %}</a>
-                {% endif %}
-                <h6 class="dropdown-header">{% trans "Support" %}</h6>
-                <a href="https://github.com/babybuddy/babybuddy" class="dropdown-item">
-                    <i class="icon-source" aria-hidden="true"></i> {% trans "Source Code" %}</a>
-                <a href="https://gitter.im/babybuddy/Lobby" class="dropdown-item">
-                    <i class="icon-chat" aria-hidden="true"></i> {% trans "Chat / Support" %}</a>
-                <h6 class="dropdown-header">v{% version_string %}</h6>
+                    <a class="text-body-secondary"
+                       href="{% url 'dashboard:dashboard' %}"
+                       aria-expanded="false"><i class="icon-2x icon-dashboard" aria-hidden="true"></i>
+                    </a>
+                    &nbsp;
+                </div>
+                <div>
+                    <a class="text-body-secondary"
+                       href="{% url 'core:timeline' %}"
+                       aria-expanded="false"><i class="icon-2x icon-timeline" aria-hidden="true"></i>
+                    </a>
+                    &nbsp;
+                </div>
             </div>
-        </li>
-    </ul>
-{% endif %}
-</div>
-</div>
-</nav>
+            <div class="d-lg-none d-md-none d-flex ms-auto p-0 me-2">
+                {% quick_timer_nav %}
+                <div class="dropdown show">
+                    <a class="text-success"
+                       href="#"
+                       role="button"
+                       id="nav-quick-add-link"
+                       data-bs-toggle="dropdown"
+                       aria-haspopup="true"
+                       aria-expanded="false"><i class="icon-2x icon-add" aria-hidden="true"></i>
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-end"
+                         aria-labelledby="nav-quick-add-link">
+                        {% if perms.core.add_diaperchange %}
+                            <a class="dropdown-item p-2" href="{% url 'core:diaperchange-add' %}">
+                                <i class="icon-diaperchange" aria-hidden="true"></i>
+                                {% trans "Diaper Change" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_feeding %}
+                            <a class="dropdown-item p-2" href="{% url 'core:feeding-add' %}">
+                                <i class="icon-feeding" aria-hidden="true"></i>
+                                {% trans "Feeding" %}
+                            </a>
+                            <a class="dropdown-item p-2" href="{% url 'core:bottle-feeding-add' %}">
+                                <i class="icon-feeding" aria-hidden="true"></i>
+                                {% trans "Bottle Feeding" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_medication %}
+                            <a class="dropdown-item p-2" href="{% url 'core:medication-add' %}">
+                                <i class="icon-medication" aria-hidden="true"></i>
+                                {% trans "Medication" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_pumping %}
+                            <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
+                                <i class="icon-pumping" aria-hidden="true"></i>
+                                {% trans "Pumping" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_note %}
+                            <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
+                                <i class="icon-note" aria-hidden="true"></i>
+                                {% trans "Note" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_sleep %}
+                            <a class="dropdown-item p-2" href="{% url 'core:sleep-add' %}">
+                                <i class="icon-sleep" aria-hidden="true"></i>
+                                {% trans "Sleep" %}
+                            </a>
+                        {% endif %}
+                        {% if  perms.core.add_tummytime %}
+                            <a class="dropdown-item p-2" href="{% url 'core:tummytime-add' %}">
+                                <i class="icon-tummytime" aria-hidden="true"></i>
+                                {% trans "Tummy Time" %}
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <button class="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbar-app"
+                    aria-controls="navbar-app"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbar-app">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item{% if request.path == '/' %} active{% endif %}">
+                        <a class="nav-link" href="{% url 'dashboard:dashboard' %}">
+                            <i class="icon-dashboard" aria-hidden="true"></i>
+                            {% trans "Dashboard" %}
+                        </a>
+                    </li>
+                    <li class="nav-item{% if request.path == '/timeline' %} active{% endif %}">
+                        <a class="nav-link" href="{% url 'core:timeline' %}">
+                            <i class="icon-timeline" aria-hidden="true"></i>
+                            {% trans "Timeline" %}
+                        </a>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-children-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-child" aria-hidden="true"></i>
+                            {% trans "Children" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-children-menu-link">
+                            {% if perms.core.view_child %}
+                                <a class="dropdown-item{% if request.path == '/children/' %} active{% endif %}"
+                                   href="{% url 'core:child-list' %}">
+                                    <i class="icon-child" aria-hidden="true"></i>
+                                    {% trans "Children" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_child %}
+                                <a class="dropdown-item ps-5{% if request.path == '/children/add/' %} active{% endif %}"
+                                   href="{% url 'core:child-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Child" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_note %}
+                                <a class="dropdown-item{% if request.path == '/notes/' %} active{% endif %}"
+                                   href="{% url 'core:note-list' %}">
+                                    <i class="icon-note" aria-hidden="true"></i>
+                                    {% trans "Notes" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_note %}
+                                <a class="dropdown-item ps-5{% if request.path == '/notes/add/' %} active{% endif %}"
+                                   href="{% url 'core:note-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Note" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-measurements-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-measurements" aria-hidden="true"></i>
+                            {% trans "Measurements" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-measurements-menu-link">
+                            {% if perms.core.view_bmi %}
+                                <a class="dropdown-item{% if request.path == '/bmi/' %} active{% endif %}"
+                                   href="{% url 'core:bmi-list' %}">
+                                    <i class="icon-bmi" aria-hidden="true"></i>
+                                    {% trans "BMI" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_bmi %}
+                                <a class="dropdown-item ps-5{% if request.path == '/bmi/add/' %} active{% endif %}"
+                                   href="{% url 'core:bmi-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "BMI entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_head_circumference %}
+                                <a class="dropdown-item{% if request.path == '/head-circumference/' %} active{% endif %}"
+                                   href="{% url 'core:head-circumference-list' %}">
+                                    <i class="icon-head-circumference" aria-hidden="true"></i>
+                                    {% trans "Head Circumference" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_head_circumference %}
+                                <a class="dropdown-item ps-5{% if request.path == '/head-circumference/add/' %} active{% endif %}"
+                                   href="{% url 'core:head-circumference-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Head Circumference entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_height %}
+                                <a class="dropdown-item{% if request.path == '/height/' %} active{% endif %}"
+                                   href="{% url 'core:height-list' %}">
+                                    <i class="icon-height" aria-hidden="true"></i>
+                                    {% trans "Height" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_height %}
+                                <a class="dropdown-item ps-5{% if request.path == '/height/add/' %} active{% endif %}"
+                                   href="{% url 'core:height-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Height entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_temperature %}
+                                <a class="dropdown-item{% if request.path == '/temperature/' %} active{% endif %}"
+                                   href="{% url 'core:temperature-list' %}">
+                                    <i class="icon-temperature" aria-hidden="true"></i>
+                                    {% trans "Temperature" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_temperature %}
+                                <a class="dropdown-item ps-5{% if request.path == '/temperature/add/' %} active{% endif %}"
+                                   href="{% url 'core:temperature-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Temperature reading" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_weight %}
+                                <a class="dropdown-item{% if request.path == '/weight/' %} active{% endif %}"
+                                   href="{% url 'core:weight-list' %}">
+                                    <i class="icon-weight" aria-hidden="true"></i>
+                                    {% trans "Weight" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_weight %}
+                                <a class="dropdown-item ps-5{% if request.path == '/weight/add/' %} active{% endif %}"
+                                   href="{% url 'core:weight-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Weight entry" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-activity-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-activities" aria-hidden="true"></i>
+                            {% trans "Activities" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-activity-menu-link">
+                            {% if perms.core.view_diaperchange %}
+                                <a class="dropdown-item{% if request.path == '/changes/' %} active{% endif %}"
+                                   href="{% url 'core:diaperchange-list' %}"><i class="icon-diaperchange" aria-hidden="true"></i>
+                                    {% trans "Changes" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_diaperchange %}
+                                <a class="dropdown-item ps-5{% if request.path == '/changes/add/' %} active{% endif %}"
+                                   href="{% url 'core:diaperchange-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Change" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_feeding %}
+                                <a class="dropdown-item{% if request.path == '/feedings/' %} active{% endif %}"
+                                   href="{% url 'core:feeding-list' %}"><i class="icon-feeding" aria-hidden="true"></i>
+                                    {% trans "Feedings" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_feeding %}
+                                <a class="dropdown-item ps-5{% if request.path == '/feedings/add/' %} active{% endif %}"
+                                   href="{% url 'core:feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Feeding" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_feeding %}
+                                <a class="dropdown-item ps-5{% if request.path == '/feedings/bottle/add/' %} active{% endif %}"
+                                   href="{% url 'core:bottle-feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Bottle Feeding" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_medication %}
+                                <a class="dropdown-item{% if request.path == '/medication/' %} active{% endif %}"
+                                   href="{% url 'core:medication-list' %}"><i class="icon-medication" aria-hidden="true"></i>
+                                    {% trans "Medication" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_medication %}
+                                <a class="dropdown-item ps-5{% if request.path == '/medication/add/' %} active{% endif %}"
+                                   href="{% url 'core:medication-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Medication" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_pumping %}
+                                <a class="dropdown-item{% if request.path == '/pumping/' %} active{% endif %}"
+                                   href="{% url 'core:pumping-list' %}">
+                                    <i class="icon-pumping" aria-hidden="true"></i>
+                                    {% trans "Pumping" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_pumping %}
+                                <a class="dropdown-item ps-5{% if request.path == '/pumping/add/' %} active{% endif %}"
+                                   href="{% url 'core:pumping-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Pumping entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_sleep %}
+                                <a class="dropdown-item{% if request.path == '/sleep/' %} active{% endif %}"
+                                   href="{% url 'core:sleep-list' %}"><i class="icon-sleep" aria-hidden="true"></i>
+                                    {% trans "Sleep" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_sleep %}
+                                <a class="dropdown-item ps-5{% if request.path == '/sleep/add/' %} active{% endif %}"
+                                   href="{% url 'core:sleep-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Sleep entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_tummytime %}
+                                <a class="dropdown-item{% if request.path == '/tummy-time/' %} active{% endif %}"
+                                   href="{% url 'core:tummytime-list' %}"><i class="icon-tummytime" aria-hidden="true"></i>
+                                    {% trans "Tummy Time" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_tummytime %}
+                                <a class="dropdown-item ps-5{% if request.path == '/tummy-time/add/' %} active{% endif %}"
+                                   href="{% url 'core:tummytime-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Tummy Time entry" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    {% if perms.core.view_timer %}
+                        {% timer_nav %}
+                    {% endif %}
+                </ul>
+                {% if request.user %}
+                    <ul class="navbar-nav ms-auto">
+                        <li class="nav-item dropdown">
+                            <a id="nav-user-menu-link"
+                               class="nav-link dropdown-toggle"
+                               href="#"
+                               data-bs-toggle="dropdown"
+                               aria-haspopup="true"
+                               aria-expanded="false">
+                                <i class="icon-user" aria-hidden="true"></i>
+                                {% firstof user.get_full_name user.get_username %}
+                            </a>
+                            <div class="dropdown-menu dropdown-menu-end"
+                                 aria-labelledby="nav-user-menu-link">
+                                <h6 class="dropdown-header">{% trans "User" %}</h6>
+                                <a href="{% url 'babybuddy:user-settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
+                                <a href="{% url 'babybuddy:user-password' %}" class="dropdown-item">{% trans "Password" %}</a>
+                                <a href="{% url 'babybuddy:user-add-device' %}" class="dropdown-item">{% trans "Add a device" %}</a>
+                                <form action="{% url 'babybuddy:logout' %}" role="form" method="post">
+                                    {% csrf_token %}
+                                    <button class="dropdown-item">{% trans "Logout" %}</button>
+                                </form>
+                                <h6 class="dropdown-header">{% trans "Site" %}</h6>
+                                <a href="{% url 'api:api-root' %}" class="dropdown-item">{% trans "API Browser" %}</a>
+                                {% if request.user.is_staff %}
+                                    <a href="{% url 'babybuddy:site_settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
+                                    <a href="{% url 'core:tag-list' %}" class="dropdown-item">{% trans "Tags" %}</a>
+                                    <a href="{% url 'babybuddy:user-list' %}" class="dropdown-item">{% trans "Users" %}</a>
+                                    <a href="{% url 'admin:index' %}" class="dropdown-item">{% trans "Database Admin" %}</a>
+                                {% endif %}
+                                <h6 class="dropdown-header">{% trans "Support" %}</h6>
+                                <a href="https://github.com/babybuddy/babybuddy" class="dropdown-item">
+                                    <i class="icon-source" aria-hidden="true"></i> {% trans "Source Code" %}</a>
+                                <a href="https://gitter.im/babybuddy/Lobby" class="dropdown-item">
+                                    <i class="icon-chat" aria-hidden="true"></i> {% trans "Chat / Support" %}</a>
+                                <h6 class="dropdown-header">v{% version_string %}</h6>
+                            </div>
+                        </li>
+                    </ul>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
 {% endblock %}

--- a/core/static_src/js/timer.js
+++ b/core/static_src/js/timer.js
@@ -77,23 +77,44 @@ BabyBuddy.Timer = (function ($) {
       h.text(hours + 1);
     },
 
+    handleStoppedTimer: function () {
+      clearInterval(runIntervalId);
+
+      $("#timer-stopped-message").removeClass("d-none");
+
+      $("#timer-actions")
+        .find("a, button")
+        .addClass("disabled")
+        .prop("disabled", true);
+    },
+
     update: function () {
-      $.get("/api/timers/" + timerId + "/", function (data) {
-        if (data && "duration" in data) {
-          clearInterval(runIntervalId);
-          var duration = data.duration.split(/[\s:.]/);
-          if (duration.length === 5) {
-            duration[0] = parseInt(duration[0]) * 24 + parseInt(duration[1]);
-            duration[1] = duration[2];
-            duration[2] = duration[3];
+      $.get("/api/timers/" + timerId + "/")
+        .done(function (data) {
+          if (data && "duration" in data) {
+            clearInterval(runIntervalId);
+
+            var duration = data.duration.split(/[\s:.]/);
+
+            if (duration.length === 5) {
+              duration[0] = parseInt(duration[0]) * 24 + parseInt(duration[1]);
+              duration[1] = duration[2];
+              duration[2] = duration[3];
+            }
+
+            timerElement.find(".timer-hours").text(parseInt(duration[0]));
+            timerElement.find(".timer-minutes").text(parseInt(duration[1]));
+            timerElement.find(".timer-seconds").text(parseInt(duration[2]));
+
+            lastUpdate = new Date();
+            runIntervalId = setInterval(Timer.tick, 1000);
           }
-          timerElement.find(".timer-hours").text(parseInt(duration[0]));
-          timerElement.find(".timer-minutes").text(parseInt(duration[1]));
-          timerElement.find(".timer-seconds").text(parseInt(duration[2]));
-          lastUpdate = new Date();
-          runIntervalId = setInterval(Timer.tick, 1000);
-        }
-      });
+        })
+        .fail(function (xhr) {
+          if (xhr.status === 404) {
+            Timer.handleStoppedTimer();
+          }
+        });
     },
   };
 

--- a/core/templates/core/quick_timer_nav.html
+++ b/core/templates/core/quick_timer_nav.html
@@ -6,33 +6,33 @@
     {% csrf_token %}
     {% if children.count > 1 %}
         <div class="dropdown show">
-        <a class="m-0 p-0 text-success"
-           title="{% trans "Quick Start Timer" %}"
-           href="#"
-           role="button"
-           id="quick-timer-menu-toggle"
-           data-bs-toggle="dropdown"
-           aria-haspopup="true"
-           aria-expanded="false"><i class="icon-2x icon-timer" aria-hidden="true"></i>
-    </a>
-    <div class="dropdown-menu dropdown-menu-end"
-         aria-labelledby="quick-timer-menu-toggle">
-        <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
-        {% for child in children %}
-            <button class="dropdown-item d-flex align-items-center"
-                    type="submit"
-                    name="child"
-                    value="{{ child.pk }}">
-                {% include "core/child_thumbnail.html" %}
-                <span class="text-wrap ms-2">{{ child }}</span>
-            </button>
-        {% endfor %}
-    </div>
-</div>
-{% else %}
-<label class="visually-hidden">{% trans "Quick Start Timer" %}</label>
-<button class="btn m-0 p-0 text-success">
-    <i class="icon-2x icon-timer" aria-hidden="true"></i>
-</button>
-{% endif %}
+            <a class="m-0 p-0 text-success"
+               title="{% trans "Quick Start Timer" %}"
+               href="#"
+               role="button"
+               id="quick-timer-menu-toggle"
+               data-bs-toggle="dropdown"
+               aria-haspopup="true"
+               aria-expanded="false"><i class="icon-2x icon-timer" aria-hidden="true"></i>
+            </a>
+            <div class="dropdown-menu dropdown-menu-end"
+                 aria-labelledby="quick-timer-menu-toggle">
+                <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
+                {% for child in children %}
+                    <button class="dropdown-item d-flex align-items-center"
+                            type="submit"
+                            name="child"
+                            value="{{ child.pk }}">
+                        {% include "core/child_thumbnail.html" %}
+                        <span class="text-wrap ms-2">{{ child }}</span>
+                    </button>
+                {% endfor %}
+            </div>
+        </div>
+    {% else %}
+        <label class="visually-hidden">{% trans "Quick Start Timer" %}</label>
+        <button class="btn m-0 p-0 text-success">
+            <i class="icon-2x icon-timer" aria-hidden="true"></i>
+        </button>
+    {% endif %}
 </form>

--- a/core/templates/core/timer_detail.html
+++ b/core/templates/core/timer_detail.html
@@ -16,6 +16,9 @@
                 <span class="timer-minutes">{{ object.duration|minutes }}</span>m
                 <span class="timer-seconds">{{ object.duration|seconds }}</span>s
             </h1>
+            <div id="timer-stopped-message"
+                 class="alert alert-warning d-none"
+                 role="alert">{% trans "This timer has already been stopped." %}</div>
             {% if timer.child and CHILD_COUNT > 1 %}<h2 class="text-body-secondary">{{ timer.child }}</h2>{% endif %}
             <p class="lead text-secondary">{% trans "Started" %} {{ object.start }}</p>
             <p class="text-body-secondary">
@@ -25,60 +28,61 @@
             </p>
             <div class="d-grid gap-4 mb-4">
                 {% if perms.core.add_feeding %}
-                <a class="btn btn-success btn-lg"
-                   href="{% instance_add_url 'core:feeding-add' %}"
-                   role="button"><i class="icon-feeding" aria-hidden="true"></i>
-                {% trans "Feeding" %}
-            </a>
-        {% endif %}
-        {% if perms.core.add_pumping %}
-        <a class="btn btn-success btn-lg"
-           href="{% instance_add_url 'core:pumping-add' %}"
-           role="button"><i class="icon-pumping" aria-hidden="true"></i>
-        {% trans "Pumping" %}
-    </a>
-{% endif %}
-{% if perms.core.add_sleep %}
-<a class="btn btn-success btn-lg"
-   href="{% instance_add_url 'core:sleep-add' %}"
-   role="button"><i class="icon-sleep" aria-hidden="true"></i>
-{% trans "Sleep" %}
-</a>
-{% endif %}
-{% if perms.core.add_tummytime %}
-<a class="btn btn-success btn-lg"
-   href="{% instance_add_url 'core:tummytime-add' %}"
-   role="button"><i class="icon-tummytime" aria-hidden="true"></i>
-{% trans "Tummy Time" %}
-</a>
-{% endif %}
-</div>
-<div class="center-block"
-     role="group"
-     aria-label="{% trans "Timer actions" %}">
-    {% if perms.core.delete_timer %}
-        <a class="btn btn-lg btn-danger"
-           href="{% url 'core:timer-delete' timer.id %}"
-           role="button"><i class="icon-delete" aria-hidden="true"></i></a>
-    {% endif %}
-    {% if perms.core.change_timer %}
-        <a class="btn btn-lg btn-primary"
-           href="{% url 'core:timer-update' timer.id %}"
-           role="button"><i class="icon-update" aria-hidden="true"></i></a>
-        <form action="{% url 'core:timer-restart' timer.id %}"
-              role="form"
-              method="post"
-              class="d-inline">
-            {% csrf_token %}
-            <label class="visually-hidden">{% trans "Restart timer" %}</label>
-            <button type="submit" class="btn btn-lg btn-secondary">
-                <i class="icon-refresh" aria-hidden="true"></i>
-            </button>
-        </form>
-    {% endif %}
-</div>
-</div>
-</div>
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:feeding-add' %}"
+                       role="button"><i class="icon-feeding" aria-hidden="true"></i>
+                        {% trans "Feeding" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_pumping %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:pumping-add' %}"
+                       role="button"><i class="icon-pumping" aria-hidden="true"></i>
+                        {% trans "Pumping" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_sleep %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:sleep-add' %}"
+                       role="button"><i class="icon-sleep" aria-hidden="true"></i>
+                        {% trans "Sleep" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_tummytime %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:tummytime-add' %}"
+                       role="button"><i class="icon-tummytime" aria-hidden="true"></i>
+                        {% trans "Tummy Time" %}
+                    </a>
+                {% endif %}
+            </div>
+            <div id="timer-actions"
+                 class="center-block"
+                 role="group"
+                 aria-label="{% trans "Timer actions" %}">
+                {% if perms.core.delete_timer %}
+                    <a class="btn btn-lg btn-danger"
+                       href="{% url 'core:timer-delete' timer.id %}"
+                       role="button"><i class="icon-delete" aria-hidden="true"></i></a>
+                {% endif %}
+                {% if perms.core.change_timer %}
+                    <a class="btn btn-lg btn-primary"
+                       href="{% url 'core:timer-update' timer.id %}"
+                       role="button"><i class="icon-update" aria-hidden="true"></i></a>
+                    <form action="{% url 'core:timer-restart' timer.id %}"
+                          role="form"
+                          method="post"
+                          class="d-inline">
+                        {% csrf_token %}
+                        <label class="visually-hidden">{% trans "Restart timer" %}</label>
+                        <button type="submit" class="btn btn-lg btn-secondary">
+                            <i class="icon-refresh" aria-hidden="true"></i>
+                        </button>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
 {% endblock %}
 {% block javascript %}
     <script type="application/javascript">BabyBuddy.Timer.run({{ timer.id }}, 'timer-status');</script>

--- a/core/templates/core/timer_nav.html
+++ b/core/templates/core/timer_nav.html
@@ -1,57 +1,57 @@
 {% load i18n %}
 <li class="nav-item dropdown">
-<a id="nav-timer-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-timer" aria-hidden="true"></i>
-{% trans "Timers" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-timer-menu-link">
-    {% if perms.core.add_timer %}
-        <a class="dropdown-item" href="{% url 'core:timer-add' %}">
-            <i class="icon-add" aria-hidden="true"></i> {% trans "Start Timer" %}
-        </a>
-    {% endif %}
-    {% if perms.core.view_timer %}
-        <a class="dropdown-item" href="{% url 'core:timer-list' %}">
-            <i class="icon-list" aria-hidden="true"></i> {% trans "View Timers" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_timer %}
-        <form action="{% url 'core:timer-add-quick' %}"
-              role="form"
-              method="post"
-              class="d-inline">
-            {% csrf_token %}
-            {% if children.count > 1 %}
-                <div class="dropdown-divider"></div>
-                <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
-                {% for child in children %}
-                    <button class="dropdown-item d-flex align-items-center"
-                            type="submit"
-                            name="child"
-                            value="{{ child.pk }}">
-                        {% include "core/child_thumbnail.html" %}
-                        <span class="text-wrap ms-2">{{ child }}</span>
+    <a id="nav-timer-menu-link"
+       class="nav-link dropdown-toggle"
+       href="#"
+       data-bs-toggle="dropdown"
+       aria-haspopup="true"
+       aria-expanded="false"><i class="icon-timer" aria-hidden="true"></i>
+        {% trans "Timers" %}
+    </a>
+    <div class="dropdown-menu" aria-labelledby="nav-timer-menu-link">
+        {% if perms.core.add_timer %}
+            <a class="dropdown-item" href="{% url 'core:timer-add' %}">
+                <i class="icon-add" aria-hidden="true"></i> {% trans "Start Timer" %}
+            </a>
+        {% endif %}
+        {% if perms.core.view_timer %}
+            <a class="dropdown-item" href="{% url 'core:timer-list' %}">
+                <i class="icon-list" aria-hidden="true"></i> {% trans "View Timers" %}
+            </a>
+        {% endif %}
+        {% if perms.core.add_timer %}
+            <form action="{% url 'core:timer-add-quick' %}"
+                  role="form"
+                  method="post"
+                  class="d-inline">
+                {% csrf_token %}
+                {% if children.count > 1 %}
+                    <div class="dropdown-divider"></div>
+                    <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
+                    {% for child in children %}
+                        <button class="dropdown-item d-flex align-items-center"
+                                type="submit"
+                                name="child"
+                                value="{{ child.pk }}">
+                            {% include "core/child_thumbnail.html" %}
+                            <span class="text-wrap ms-2">{{ child }}</span>
+                        </button>
+                    {% endfor %}
+                {% else %}
+                    <button class="dropdown-item" type="submit">
+                        <i class="icon-timer" aria-hidden="true"></i> {% trans "Quick Start Timer" %}
                     </button>
-                {% endfor %}
-            {% else %}
-                <button class="dropdown-item" type="submit">
-                    <i class="icon-timer" aria-hidden="true"></i> {% trans "Quick Start Timer" %}
-                </button>
-            {% endif %}
-        </form>
-    {% endif %}
-    {% if timers %}
-        <div class="dropdown-divider"></div>
-        <h6 class="dropdown-header">{% trans "Timers" %}</h6>
-        {% for timer in timers %}
-            <a class="dropdown-item" href="{% url 'core:timer-detail' timer.id %}">{{ timer.title_with_child }}</a>
-        {% empty %}
-            <a class="dropdown-item disabled" href="#">{% trans "None" %}</a>
-        {% endfor %}
-    {% endif %}
-</div>
+                {% endif %}
+            </form>
+        {% endif %}
+        {% if timers %}
+            <div class="dropdown-divider"></div>
+            <h6 class="dropdown-header">{% trans "Timers" %}</h6>
+            {% for timer in timers %}
+                <a class="dropdown-item" href="{% url 'core:timer-detail' timer.id %}">{{ timer.title_with_child }}</a>
+            {% empty %}
+                <a class="dropdown-item disabled" href="#">{% trans "None" %}</a>
+            {% endfor %}
+        {% endif %}
+    </div>
 </li>


### PR DESCRIPTION
## Description
This PR addresses the issue of active timers getting out of sync when closed from a different device or browser session. 

When a timer is ended elsewhere, the detail page now detects the missing/inactive state (handling the API 404 response), stops updating the UI clock, displays a clear notification message to the user, and disables any invalid actions.

<img width="1917" height="834" alt="image" src="https://github.com/user-attachments/assets/7498d932-aa48-4908-bc2c-8089f7662b56" />

## Related Issues
- Closes #983

## Changes
- [x] Added periodic check to verify if the active timer still exists on the server.
- [x] Implemented handling for API `404 Not Found` errors to stop the countdown.
- [x] Added a warning message informing the user that the timer has already been ended.
- [x] Disabled timer-related action buttons once the end state is detected.

## Test Plan
- Verify that a 404 response on the timer poll endpoint triggers the alert banner.
- Ensure buttons (like stop, edit, or delete) are disabled after the notification appears.