### PR TITLE
fix: span the child column in empty notes tables

### DIFF
--- a/babybuddy/templates/babybuddy/form_field_no_label.html
+++ b/babybuddy/templates/babybuddy/form_field_no_label.html
@@ -31,5 +31,5 @@
     </div>
 {% endif %}
 {% if field.errors %}
-    <div class="invalid-feedback">{% for error in  field.errors %}{{ error }}{% endfor %}</div>
+    <div class="invalid-feedback">{% for error in field.errors %}{{ error }}{% endfor %}</div>
 {% endif %}

--- a/babybuddy/templates/babybuddy/nav-dropdown.html
+++ b/babybuddy/templates/babybuddy/nav-dropdown.html
@@ -15,356 +15,356 @@
             </a>
             <div class="d-lg-none d-md-none d-flex me-auto p-0 ms-2">
                 <div>
-                <a class="text-body-secondary"
-                   href="{% url 'dashboard:dashboard' %}"
-                   aria-expanded="false"><i class="icon-2x icon-dashboard" aria-hidden="true"></i>
-            </a>
-            &nbsp;
-        </div>
-        <div>
-        <a class="text-body-secondary"
-           href="{% url 'core:timeline' %}"
-           aria-expanded="false"><i class="icon-2x icon-timeline" aria-hidden="true"></i>
-    </a>
-    &nbsp;
-</div>
-</div>
-<div class="d-lg-none d-md-none d-flex ms-auto p-0 me-2">
-    {% quick_timer_nav %}
-    <div class="dropdown show">
-    <a class="text-success"
-       href="#"
-       role="button"
-       id="nav-quick-add-link"
-       data-bs-toggle="dropdown"
-       aria-haspopup="true"
-       aria-expanded="false"><i class="icon-2x icon-add" aria-hidden="true"></i>
-</a>
-<div class="dropdown-menu dropdown-menu-end"
-     aria-labelledby="nav-quick-add-link">
-    {% if perms.core.add_diaperchange %}
-        <a class="dropdown-item p-2" href="{% url 'core:diaperchange-add' %}">
-            <i class="icon-diaperchange" aria-hidden="true"></i>
-            {% trans "Diaper Change" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_feeding %}
-        <a class="dropdown-item p-2" href="{% url 'core:feeding-add' %}">
-            <i class="icon-feeding" aria-hidden="true"></i>
-            {% trans "Feeding" %}
-        </a>
-        <a class="dropdown-item p-2" href="{% url 'core:bottle-feeding-add' %}">
-            <i class="icon-feeding" aria-hidden="true"></i>
-            {% trans "Bottle Feeding" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_medication %}
-        <a class="dropdown-item p-2" href="{% url 'core:medication-add' %}">
-            <i class="icon-medication" aria-hidden="true"></i>
-            {% trans "Medication" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_pumping %}
-        <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
-            <i class="icon-pumping" aria-hidden="true"></i>
-            {% trans "Pumping" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_note %}
-        <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
-            <i class="icon-note" aria-hidden="true"></i>
-            {% trans "Note" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_sleep %}
-        <a class="dropdown-item p-2" href="{% url 'core:sleep-add' %}">
-            <i class="icon-sleep" aria-hidden="true"></i>
-            {% trans "Sleep" %}
-        </a>
-    {% endif %}
-    {% if  perms.core.add_tummytime %}
-        <a class="dropdown-item p-2" href="{% url 'core:tummytime-add' %}">
-            <i class="icon-tummytime" aria-hidden="true"></i>
-            {% trans "Tummy Time" %}
-        </a>
-    {% endif %}
-</div>
-</div>
-</div>
-<button class="navbar-toggler"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#navbar-app"
-        aria-controls="navbar-app"
-        aria-expanded="false"
-        aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-</button>
-<div class="collapse navbar-collapse" id="navbar-app">
-    <ul class="navbar-nav me-auto">
-        <li class="nav-item{% if request.path == '/' %} active{% endif %}">
-            <a class="nav-link" href="{% url 'dashboard:dashboard' %}">
-                <i class="icon-dashboard" aria-hidden="true"></i>
-                {% trans "Dashboard" %}
-            </a>
-        </li>
-        <li class="nav-item{% if request.path == '/timeline' %} active{% endif %}">
-            <a class="nav-link" href="{% url 'core:timeline' %}">
-                <i class="icon-timeline" aria-hidden="true"></i>
-                {% trans "Timeline" %}
-            </a>
-        </li>
-        <li class="nav-item dropdown">
-        <a id="nav-children-menu-link"
-           class="nav-link dropdown-toggle"
-           href="#"
-           data-bs-toggle="dropdown"
-           aria-haspopup="true"
-           aria-expanded="false"><i class="icon-child" aria-hidden="true"></i>
-        {% trans "Children" %}
-    </a>
-    <div class="dropdown-menu" aria-labelledby="nav-children-menu-link">
-        {% if perms.core.view_child %}
-            <a class="dropdown-item{% if request.path == '/children/' %} active{% endif %}"
-               href="{% url 'core:child-list' %}">
-                <i class="icon-child" aria-hidden="true"></i>
-                {% trans "Children" %}
-            </a>
-        {% endif %}
-        {% if perms.core.add_child %}
-        <a class="dropdown-item ps-5{% if request.path == '/children/add/' %} active{% endif %}"
-           href="{% url 'core:child-add' %}"><i class="icon-add" aria-hidden="true"></i>
-        {% trans "Child" %}
-    </a>
-{% endif %}
-{% if perms.core.view_note %}
-    <a class="dropdown-item{% if request.path == '/notes/' %} active{% endif %}"
-       href="{% url 'core:note-list' %}">
-        <i class="icon-note" aria-hidden="true"></i>
-        {% trans "Notes" %}
-    </a>
-{% endif %}
-{% if perms.core.add_note %}
-<a class="dropdown-item ps-5{% if request.path == '/notes/add/' %} active{% endif %}"
-   href="{% url 'core:note-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Note" %}
-</a>
-{% endif %}
-</div>
-</li>
-<li class="nav-item dropdown">
-<a id="nav-measurements-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-measurements" aria-hidden="true"></i>
-{% trans "Measurements" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-measurements-menu-link">
-    {% if perms.core.view_bmi %}
-        <a class="dropdown-item{% if request.path == '/bmi/' %} active{% endif %}"
-           href="{% url 'core:bmi-list' %}">
-            <i class="icon-bmi" aria-hidden="true"></i>
-            {% trans "BMI" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_bmi %}
-    <a class="dropdown-item ps-5{% if request.path == '/bmi/add/' %} active{% endif %}"
-       href="{% url 'core:bmi-add' %}"><i class="icon-add" aria-hidden="true"></i>
-    {% trans "BMI entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_head_circumference %}
-    <a class="dropdown-item{% if request.path == '/head-circumference/' %} active{% endif %}"
-       href="{% url 'core:head-circumference-list' %}">
-        <i class="icon-head-circumference" aria-hidden="true"></i>
-        {% trans "Head Circumference" %}
-    </a>
-{% endif %}
-{% if perms.core.add_head_circumference %}
-<a class="dropdown-item ps-5{% if request.path == '/head-circumference/add/' %} active{% endif %}"
-   href="{% url 'core:head-circumference-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Head Circumference entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_height %}
-    <a class="dropdown-item{% if request.path == '/height/' %} active{% endif %}"
-       href="{% url 'core:height-list' %}">
-        <i class="icon-height" aria-hidden="true"></i>
-        {% trans "Height" %}
-    </a>
-{% endif %}
-{% if perms.core.add_height %}
-<a class="dropdown-item ps-5{% if request.path == '/height/add/' %} active{% endif %}"
-   href="{% url 'core:height-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Height entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_temperature %}
-    <a class="dropdown-item{% if request.path == '/temperature/' %} active{% endif %}"
-       href="{% url 'core:temperature-list' %}">
-        <i class="icon-temperature" aria-hidden="true"></i>
-        {% trans "Temperature" %}
-    </a>
-{% endif %}
-{% if perms.core.add_temperature %}
-<a class="dropdown-item ps-5{% if request.path == '/temperature/add/' %} active{% endif %}"
-   href="{% url 'core:temperature-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Temperature reading" %}
-</a>
-{% endif %}
-{% if perms.core.view_weight %}
-    <a class="dropdown-item{% if request.path == '/weight/' %} active{% endif %}"
-       href="{% url 'core:weight-list' %}">
-        <i class="icon-weight" aria-hidden="true"></i>
-        {% trans "Weight" %}
-    </a>
-{% endif %}
-{% if perms.core.add_weight %}
-<a class="dropdown-item ps-5{% if request.path == '/weight/add/' %} active{% endif %}"
-   href="{% url 'core:weight-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Weight entry" %}
-</a>
-{% endif %}
-</div>
-</li>
-<li class="nav-item dropdown">
-<a id="nav-activity-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-activities" aria-hidden="true"></i>
-{% trans "Activities" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-activity-menu-link">
-    {% if perms.core.view_diaperchange %}
-    <a class="dropdown-item{% if request.path == '/changes/' %} active{% endif %}"
-       href="{% url 'core:diaperchange-list' %}"><i class="icon-diaperchange" aria-hidden="true"></i>
-    {% trans "Changes" %}
-</a>
-{% endif %}
-{% if perms.core.add_diaperchange %}
-<a class="dropdown-item ps-5{% if request.path == '/changes/add/' %} active{% endif %}"
-   href="{% url 'core:diaperchange-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Change" %}
-</a>
-{% endif %}
-{% if perms.core.view_feeding %}
-<a class="dropdown-item{% if request.path == '/feedings/' %} active{% endif %}"
-   href="{% url 'core:feeding-list' %}"><i class="icon-feeding" aria-hidden="true"></i>
-{% trans "Feedings" %}
-</a>
-{% endif %}
-{% if perms.core.add_feeding %}
-<a class="dropdown-item ps-5{% if request.path == '/feedings/add/' %} active{% endif %}"
-   href="{% url 'core:feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Feeding" %}
-</a>
-{% endif %}
-{% if perms.core.add_feeding %}
-<a class="dropdown-item ps-5{% if request.path == '/feedings/bottle/add/' %} active{% endif %}"
-   href="{% url 'core:bottle-feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Bottle Feeding" %}
-</a>
-{% endif %}
-{% if perms.core.view_medication %}
-<a class="dropdown-item{% if request.path == '/medication/' %} active{% endif %}"
-   href="{% url 'core:medication-list' %}"><i class="icon-medication" aria-hidden="true"></i>
-{% trans "Medication" %}
-</a>
-{% endif %}
-{% if perms.core.add_medication %}
-<a class="dropdown-item ps-5{% if request.path == '/medication/add/' %} active{% endif %}"
-   href="{% url 'core:medication-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Medication" %}
-</a>
-{% endif %}
-{% if perms.core.view_pumping %}
-    <a class="dropdown-item{% if request.path == '/pumping/' %} active{% endif %}"
-       href="{% url 'core:pumping-list' %}">
-        <i class="icon-pumping" aria-hidden="true"></i>
-        {% trans "Pumping" %}
-    </a>
-{% endif %}
-{% if perms.core.add_pumping %}
-<a class="dropdown-item ps-5{% if request.path == '/pumping/add/' %} active{% endif %}"
-   href="{% url 'core:pumping-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Pumping entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_sleep %}
-<a class="dropdown-item{% if request.path == '/sleep/' %} active{% endif %}"
-   href="{% url 'core:sleep-list' %}"><i class="icon-sleep" aria-hidden="true"></i>
-{% trans "Sleep" %}
-</a>
-{% endif %}
-{% if perms.core.add_sleep %}
-<a class="dropdown-item ps-5{% if request.path == '/sleep/add/' %} active{% endif %}"
-   href="{% url 'core:sleep-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Sleep entry" %}
-</a>
-{% endif %}
-{% if perms.core.view_tummytime %}
-<a class="dropdown-item{% if request.path == '/tummy-time/' %} active{% endif %}"
-   href="{% url 'core:tummytime-list' %}"><i class="icon-tummytime" aria-hidden="true"></i>
-{% trans "Tummy Time" %}
-</a>
-{% endif %}
-{% if perms.core.add_tummytime %}
-<a class="dropdown-item ps-5{% if request.path == '/tummy-time/add/' %} active{% endif %}"
-   href="{% url 'core:tummytime-add' %}"><i class="icon-add" aria-hidden="true"></i>
-{% trans "Tummy Time entry" %}
-</a>
-{% endif %}
-</div>
-</li>
-{% if perms.core.view_timer %}
-    {% timer_nav %}
-{% endif %}
-</ul>
-{% if request.user %}
-    <ul class="navbar-nav ms-auto">
-        <li class="nav-item dropdown">
-            <a id="nav-user-menu-link"
-               class="nav-link dropdown-toggle"
-               href="#"
-               data-bs-toggle="dropdown"
-               aria-haspopup="true"
-               aria-expanded="false">
-                <i class="icon-user" aria-hidden="true"></i>
-                {% firstof user.get_full_name user.get_username %}
-            </a>
-            <div class="dropdown-menu dropdown-menu-end"
-                 aria-labelledby="nav-user-menu-link">
-                <h6 class="dropdown-header">{% trans "User" %}</h6>
-                <a href="{% url 'babybuddy:user-settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
-                <a href="{% url 'babybuddy:user-password' %}" class="dropdown-item">{% trans "Password" %}</a>
-                <a href="{% url 'babybuddy:user-add-device' %}" class="dropdown-item">{% trans "Add a device" %}</a>
-                <form action="{% url 'babybuddy:logout' %}" role="form" method="post">
-                    {% csrf_token %}
-                    <button class="dropdown-item">{% trans "Logout" %}</button>
-                </form>
-                <h6 class="dropdown-header">{% trans "Site" %}</h6>
-                <a href="{% url 'api:api-root' %}" class="dropdown-item">{% trans "API Browser" %}</a>
-                {% if request.user.is_staff %}
-                    <a href="{% url 'babybuddy:site_settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
-                    <a href="{% url 'core:tag-list' %}" class="dropdown-item">{% trans "Tags" %}</a>
-                    <a href="{% url 'babybuddy:user-list' %}" class="dropdown-item">{% trans "Users" %}</a>
-                    <a href="{% url 'admin:index' %}" class="dropdown-item">{% trans "Database Admin" %}</a>
-                {% endif %}
-                <h6 class="dropdown-header">{% trans "Support" %}</h6>
-                <a href="https://github.com/babybuddy/babybuddy" class="dropdown-item">
-                    <i class="icon-source" aria-hidden="true"></i> {% trans "Source Code" %}</a>
-                <a href="https://gitter.im/babybuddy/Lobby" class="dropdown-item">
-                    <i class="icon-chat" aria-hidden="true"></i> {% trans "Chat / Support" %}</a>
-                <h6 class="dropdown-header">v{% version_string %}</h6>
+                    <a class="text-body-secondary"
+                       href="{% url 'dashboard:dashboard' %}"
+                       aria-expanded="false"><i class="icon-2x icon-dashboard" aria-hidden="true"></i>
+                    </a>
+                    &nbsp;
+                </div>
+                <div>
+                    <a class="text-body-secondary"
+                       href="{% url 'core:timeline' %}"
+                       aria-expanded="false"><i class="icon-2x icon-timeline" aria-hidden="true"></i>
+                    </a>
+                    &nbsp;
+                </div>
             </div>
-        </li>
-    </ul>
-{% endif %}
-</div>
-</div>
-</nav>
+            <div class="d-lg-none d-md-none d-flex ms-auto p-0 me-2">
+                {% quick_timer_nav %}
+                <div class="dropdown show">
+                    <a class="text-success"
+                       href="#"
+                       role="button"
+                       id="nav-quick-add-link"
+                       data-bs-toggle="dropdown"
+                       aria-haspopup="true"
+                       aria-expanded="false"><i class="icon-2x icon-add" aria-hidden="true"></i>
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-end"
+                         aria-labelledby="nav-quick-add-link">
+                        {% if perms.core.add_diaperchange %}
+                            <a class="dropdown-item p-2" href="{% url 'core:diaperchange-add' %}">
+                                <i class="icon-diaperchange" aria-hidden="true"></i>
+                                {% trans "Diaper Change" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_feeding %}
+                            <a class="dropdown-item p-2" href="{% url 'core:feeding-add' %}">
+                                <i class="icon-feeding" aria-hidden="true"></i>
+                                {% trans "Feeding" %}
+                            </a>
+                            <a class="dropdown-item p-2" href="{% url 'core:bottle-feeding-add' %}">
+                                <i class="icon-feeding" aria-hidden="true"></i>
+                                {% trans "Bottle Feeding" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_medication %}
+                            <a class="dropdown-item p-2" href="{% url 'core:medication-add' %}">
+                                <i class="icon-medication" aria-hidden="true"></i>
+                                {% trans "Medication" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_pumping %}
+                            <a class="dropdown-item p-2" href="{% url 'core:pumping-add' %}">
+                                <i class="icon-pumping" aria-hidden="true"></i>
+                                {% trans "Pumping" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_note %}
+                            <a class="dropdown-item p-2" href="{% url 'core:note-add' %}">
+                                <i class="icon-note" aria-hidden="true"></i>
+                                {% trans "Note" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_sleep %}
+                            <a class="dropdown-item p-2" href="{% url 'core:sleep-add' %}">
+                                <i class="icon-sleep" aria-hidden="true"></i>
+                                {% trans "Sleep" %}
+                            </a>
+                        {% endif %}
+                        {% if perms.core.add_tummytime %}
+                            <a class="dropdown-item p-2" href="{% url 'core:tummytime-add' %}">
+                                <i class="icon-tummytime" aria-hidden="true"></i>
+                                {% trans "Tummy Time" %}
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <button class="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbar-app"
+                    aria-controls="navbar-app"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbar-app">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item{% if request.path == '/' %} active{% endif %}">
+                        <a class="nav-link" href="{% url 'dashboard:dashboard' %}">
+                            <i class="icon-dashboard" aria-hidden="true"></i>
+                            {% trans "Dashboard" %}
+                        </a>
+                    </li>
+                    <li class="nav-item{% if request.path == '/timeline' %} active{% endif %}">
+                        <a class="nav-link" href="{% url 'core:timeline' %}">
+                            <i class="icon-timeline" aria-hidden="true"></i>
+                            {% trans "Timeline" %}
+                        </a>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-children-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-child" aria-hidden="true"></i>
+                            {% trans "Children" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-children-menu-link">
+                            {% if perms.core.view_child %}
+                                <a class="dropdown-item{% if request.path == '/children/' %} active{% endif %}"
+                                   href="{% url 'core:child-list' %}">
+                                    <i class="icon-child" aria-hidden="true"></i>
+                                    {% trans "Children" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_child %}
+                                <a class="dropdown-item ps-5{% if request.path == '/children/add/' %} active{% endif %}"
+                                   href="{% url 'core:child-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Child" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_note %}
+                                <a class="dropdown-item{% if request.path == '/notes/' %} active{% endif %}"
+                                   href="{% url 'core:note-list' %}">
+                                    <i class="icon-note" aria-hidden="true"></i>
+                                    {% trans "Notes" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_note %}
+                                <a class="dropdown-item ps-5{% if request.path == '/notes/add/' %} active{% endif %}"
+                                   href="{% url 'core:note-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Note" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-measurements-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-measurements" aria-hidden="true"></i>
+                            {% trans "Measurements" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-measurements-menu-link">
+                            {% if perms.core.view_bmi %}
+                                <a class="dropdown-item{% if request.path == '/bmi/' %} active{% endif %}"
+                                   href="{% url 'core:bmi-list' %}">
+                                    <i class="icon-bmi" aria-hidden="true"></i>
+                                    {% trans "BMI" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_bmi %}
+                                <a class="dropdown-item ps-5{% if request.path == '/bmi/add/' %} active{% endif %}"
+                                   href="{% url 'core:bmi-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "BMI entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_head_circumference %}
+                                <a class="dropdown-item{% if request.path == '/head-circumference/' %} active{% endif %}"
+                                   href="{% url 'core:head-circumference-list' %}">
+                                    <i class="icon-head-circumference" aria-hidden="true"></i>
+                                    {% trans "Head Circumference" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_head_circumference %}
+                                <a class="dropdown-item ps-5{% if request.path == '/head-circumference/add/' %} active{% endif %}"
+                                   href="{% url 'core:head-circumference-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Head Circumference entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_height %}
+                                <a class="dropdown-item{% if request.path == '/height/' %} active{% endif %}"
+                                   href="{% url 'core:height-list' %}">
+                                    <i class="icon-height" aria-hidden="true"></i>
+                                    {% trans "Height" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_height %}
+                                <a class="dropdown-item ps-5{% if request.path == '/height/add/' %} active{% endif %}"
+                                   href="{% url 'core:height-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Height entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_temperature %}
+                                <a class="dropdown-item{% if request.path == '/temperature/' %} active{% endif %}"
+                                   href="{% url 'core:temperature-list' %}">
+                                    <i class="icon-temperature" aria-hidden="true"></i>
+                                    {% trans "Temperature" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_temperature %}
+                                <a class="dropdown-item ps-5{% if request.path == '/temperature/add/' %} active{% endif %}"
+                                   href="{% url 'core:temperature-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Temperature reading" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_weight %}
+                                <a class="dropdown-item{% if request.path == '/weight/' %} active{% endif %}"
+                                   href="{% url 'core:weight-list' %}">
+                                    <i class="icon-weight" aria-hidden="true"></i>
+                                    {% trans "Weight" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_weight %}
+                                <a class="dropdown-item ps-5{% if request.path == '/weight/add/' %} active{% endif %}"
+                                   href="{% url 'core:weight-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Weight entry" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a id="nav-activity-menu-link"
+                           class="nav-link dropdown-toggle"
+                           href="#"
+                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
+                           aria-expanded="false"><i class="icon-activities" aria-hidden="true"></i>
+                            {% trans "Activities" %}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="nav-activity-menu-link">
+                            {% if perms.core.view_diaperchange %}
+                                <a class="dropdown-item{% if request.path == '/changes/' %} active{% endif %}"
+                                   href="{% url 'core:diaperchange-list' %}"><i class="icon-diaperchange" aria-hidden="true"></i>
+                                    {% trans "Changes" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_diaperchange %}
+                                <a class="dropdown-item ps-5{% if request.path == '/changes/add/' %} active{% endif %}"
+                                   href="{% url 'core:diaperchange-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Change" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_feeding %}
+                                <a class="dropdown-item{% if request.path == '/feedings/' %} active{% endif %}"
+                                   href="{% url 'core:feeding-list' %}"><i class="icon-feeding" aria-hidden="true"></i>
+                                    {% trans "Feedings" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_feeding %}
+                                <a class="dropdown-item ps-5{% if request.path == '/feedings/add/' %} active{% endif %}"
+                                   href="{% url 'core:feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Feeding" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_feeding %}
+                                <a class="dropdown-item ps-5{% if request.path == '/feedings/bottle/add/' %} active{% endif %}"
+                                   href="{% url 'core:bottle-feeding-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Bottle Feeding" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_medication %}
+                                <a class="dropdown-item{% if request.path == '/medication/' %} active{% endif %}"
+                                   href="{% url 'core:medication-list' %}"><i class="icon-medication" aria-hidden="true"></i>
+                                    {% trans "Medication" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_medication %}
+                                <a class="dropdown-item ps-5{% if request.path == '/medication/add/' %} active{% endif %}"
+                                   href="{% url 'core:medication-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Medication" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_pumping %}
+                                <a class="dropdown-item{% if request.path == '/pumping/' %} active{% endif %}"
+                                   href="{% url 'core:pumping-list' %}">
+                                    <i class="icon-pumping" aria-hidden="true"></i>
+                                    {% trans "Pumping" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_pumping %}
+                                <a class="dropdown-item ps-5{% if request.path == '/pumping/add/' %} active{% endif %}"
+                                   href="{% url 'core:pumping-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Pumping entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_sleep %}
+                                <a class="dropdown-item{% if request.path == '/sleep/' %} active{% endif %}"
+                                   href="{% url 'core:sleep-list' %}"><i class="icon-sleep" aria-hidden="true"></i>
+                                    {% trans "Sleep" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_sleep %}
+                                <a class="dropdown-item ps-5{% if request.path == '/sleep/add/' %} active{% endif %}"
+                                   href="{% url 'core:sleep-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Sleep entry" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.view_tummytime %}
+                                <a class="dropdown-item{% if request.path == '/tummy-time/' %} active{% endif %}"
+                                   href="{% url 'core:tummytime-list' %}"><i class="icon-tummytime" aria-hidden="true"></i>
+                                    {% trans "Tummy Time" %}
+                                </a>
+                            {% endif %}
+                            {% if perms.core.add_tummytime %}
+                                <a class="dropdown-item ps-5{% if request.path == '/tummy-time/add/' %} active{% endif %}"
+                                   href="{% url 'core:tummytime-add' %}"><i class="icon-add" aria-hidden="true"></i>
+                                    {% trans "Tummy Time entry" %}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </li>
+                    {% if perms.core.view_timer %}
+                        {% timer_nav %}
+                    {% endif %}
+                </ul>
+                {% if request.user %}
+                    <ul class="navbar-nav ms-auto">
+                        <li class="nav-item dropdown">
+                            <a id="nav-user-menu-link"
+                               class="nav-link dropdown-toggle"
+                               href="#"
+                               data-bs-toggle="dropdown"
+                               aria-haspopup="true"
+                               aria-expanded="false">
+                                <i class="icon-user" aria-hidden="true"></i>
+                                {% firstof user.get_full_name user.get_username %}
+                            </a>
+                            <div class="dropdown-menu dropdown-menu-end"
+                                 aria-labelledby="nav-user-menu-link">
+                                <h6 class="dropdown-header">{% trans "User" %}</h6>
+                                <a href="{% url 'babybuddy:user-settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
+                                <a href="{% url 'babybuddy:user-password' %}" class="dropdown-item">{% trans "Password" %}</a>
+                                <a href="{% url 'babybuddy:user-add-device' %}" class="dropdown-item">{% trans "Add a device" %}</a>
+                                <form action="{% url 'babybuddy:logout' %}" role="form" method="post">
+                                    {% csrf_token %}
+                                    <button class="dropdown-item">{% trans "Logout" %}</button>
+                                </form>
+                                <h6 class="dropdown-header">{% trans "Site" %}</h6>
+                                <a href="{% url 'api:api-root' %}" class="dropdown-item">{% trans "API Browser" %}</a>
+                                {% if request.user.is_staff %}
+                                    <a href="{% url 'babybuddy:site_settings' %}" class="dropdown-item">{% trans "Settings" %}</a>
+                                    <a href="{% url 'core:tag-list' %}" class="dropdown-item">{% trans "Tags" %}</a>
+                                    <a href="{% url 'babybuddy:user-list' %}" class="dropdown-item">{% trans "Users" %}</a>
+                                    <a href="{% url 'admin:index' %}" class="dropdown-item">{% trans "Database Admin" %}</a>
+                                {% endif %}
+                                <h6 class="dropdown-header">{% trans "Support" %}</h6>
+                                <a href="https://github.com/babybuddy/babybuddy" class="dropdown-item">
+                                    <i class="icon-source" aria-hidden="true"></i> {% trans "Source Code" %}</a>
+                                <a href="https://gitter.im/babybuddy/Lobby" class="dropdown-item">
+                                    <i class="icon-chat" aria-hidden="true"></i> {% trans "Chat / Support" %}</a>
+                                <h6 class="dropdown-header">v{% version_string %}</h6>
+                            </div>
+                        </li>
+                    </ul>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
 {% endblock %}

--- a/babybuddy/templates/babybuddy/paginator.html
+++ b/babybuddy/templates/babybuddy/paginator.html
@@ -18,32 +18,32 @@
                             <span class="visually-hidden">{% trans "Previous" %}</span>
                         </a>
                     </li>
-                {% endif %}
-                {% for num in page_obj.paginator.page_range %}
-                    {% if num > page_obj.number|add:"-3" and num < page_obj.number|add:"3" %}
-                        <li class="page-item{% if num == page_obj.number %} active{% endif %}">
-                            <a class="page-link" href="{% relative_url 'page' num %}">{{ num }}</a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-                {% if page_obj.has_next %}
-                    <li class="page-item">
-                        <a class="page-link page-link-icon"
-                           href="{% relative_url 'page' page_obj.next_page_number %}"
-                           aria-label="Next">
-                            <i class="icon-angle-right" aria-hidden="true"></i>
-                            <span class="visually-hidden">{% trans "Next" %}</span>
-                        </a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link page-link-icon"
-                           href="{% relative_url 'page' page_obj.paginator.num_pages %}"
-                           aria-label="Last">
-                            <i class="icon-angle-double-right" aria-hidden="true"></i>
-                            <span class="visually-hidden">{% trans "Last" %}</span>
-                        </a>
+            {% endif %}
+            {% for num in page_obj.paginator.page_range %}
+                {% if num > page_obj.number|add:"-3" and num < page_obj.number|add:"3" %}
+                    <li class="page-item{% if num == page_obj.number %} active{% endif %}">
+                        <a class="page-link" href="{% relative_url 'page' num %}">{{ num }}</a>
                     </li>
                 {% endif %}
-            </ul>
-        </nav>
-    {% endif %}
+            {% endfor %}
+            {% if page_obj.has_next %}
+                <li class="page-item">
+                    <a class="page-link page-link-icon"
+                       href="{% relative_url 'page' page_obj.next_page_number %}"
+                       aria-label="Next">
+                        <i class="icon-angle-right" aria-hidden="true"></i>
+                        <span class="visually-hidden">{% trans "Next" %}</span>
+                    </a>
+                </li>
+                <li class="page-item">
+                    <a class="page-link page-link-icon"
+                       href="{% relative_url 'page' page_obj.paginator.num_pages %}"
+                       aria-label="Last">
+                        <i class="icon-angle-double-right" aria-hidden="true"></i>
+                        <span class="visually-hidden">{% trans "Last" %}</span>
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
+    </nav>
+{% endif %}

--- a/babybuddy/templates/error/403_csrf_bad_origin.html
+++ b/babybuddy/templates/error/403_csrf_bad_origin.html
@@ -10,7 +10,7 @@
             <h2>{% trans "How to Fix" %}</h2>
             {% blocktrans trimmed with value="<samp>"|add:origin|add:"</samp>"|safe variable="<code>CSRF_TRUSTED_ORIGINS</code>"|safe %}
             Add {{ value }} to the {{ variable }} environment variable. If multiple origins are required separate with commas.
-        {% endblocktrans %}
-    </div>
+{% endblocktrans %}
+</div>
 </div>
 {% endblock %}

--- a/babybuddy/templates/error/404.html
+++ b/babybuddy/templates/error/404.html
@@ -8,6 +8,6 @@
     <div>
         {% blocktrans trimmed with path="<code>"|add:request_path|add"</code>"|safe %}
         The path {{ path }} does not exist.
-    {% endblocktrans %}
+{% endblocktrans %}
 </div>
 {% endblock %}

--- a/babybuddy/templates/registration/base.html
+++ b/babybuddy/templates/registration/base.html
@@ -18,5 +18,5 @@
         {% include 'babybuddy/messages.html' %}
         {% block content %}{% endblock %}
     </div>
-</div>
+    </div>
 {% endblock %}

--- a/core/templates/core/child_detail.html
+++ b/core/templates/core/child_detail.html
@@ -25,10 +25,10 @@
                         {% trans "Age" %} <span class="text-secondary">{{ object.birth_datetime|child_age_string }}</span>
                     </p>
                     {% include 'dashboard/child_button_group.html' %}
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-lg-8 offset-lg-4 col-md-6 offset-md-6 z-2">{% include 'timeline/_timeline.html' %}</div>
-        </div>
-    {% endblock %}
+                    </div>
+                    </div>
+                    </div>
+                <div class="row">
+                    <div class="col-lg-8 offset-lg-4 col-md-6 offset-md-6 z-2">{% include 'timeline/_timeline.html' %}</div>
+                    </div>
+            {% endblock %}

--- a/core/templates/core/note_list.html
+++ b/core/templates/core/note_list.html
@@ -62,17 +62,17 @@
                                         <img src="{{ thumb.url }}" class="img-fluid" />
                                     </a>
                                 {% endif %}
-                            </td>
+                                </td>
                             <td>{{ note.note }}</td>
                             <td>{% include "core/render_tag_list.html" with tags=note.tags.all %}</td>
-                        </tr>
-                    {% empty %}
-                        <tr>
-                            <th colspan="5">{% trans "No notes found." %}</th>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% include 'babybuddy/paginator.html' %}
-    {% endblock %}
+                                </tr>
+                            {% empty %}
+                                <tr>
+                                    <th colspan="5">{% trans "No notes found." %}</th>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    </div>
+                {% include 'babybuddy/paginator.html' %}
+            {% endblock %}

--- a/core/templates/core/note_list.html
+++ b/core/templates/core/note_list.html
@@ -68,7 +68,7 @@
                                 </tr>
                             {% empty %}
                                 <tr>
-                                    <th colspan="5">{% trans "No notes found." %}</th>
+                                    <th colspan="{% if not unique_child %} 6 {% else %} 5 {% endif %}">{% trans "No notes found." %}</th>
                                 </tr>
                             {% endfor %}
                         </tbody>

--- a/core/templates/core/quick_timer_nav.html
+++ b/core/templates/core/quick_timer_nav.html
@@ -6,33 +6,33 @@
     {% csrf_token %}
     {% if children.count > 1 %}
         <div class="dropdown show">
-        <a class="m-0 p-0 text-success"
-           title="{% trans "Quick Start Timer" %}"
-           href="#"
-           role="button"
-           id="quick-timer-menu-toggle"
-           data-bs-toggle="dropdown"
-           aria-haspopup="true"
-           aria-expanded="false"><i class="icon-2x icon-timer" aria-hidden="true"></i>
-    </a>
-    <div class="dropdown-menu dropdown-menu-end"
-         aria-labelledby="quick-timer-menu-toggle">
-        <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
-        {% for child in children %}
-            <button class="dropdown-item d-flex align-items-center"
-                    type="submit"
-                    name="child"
-                    value="{{ child.pk }}">
-                {% include "core/child_thumbnail.html" %}
-                <span class="text-wrap ms-2">{{ child }}</span>
-            </button>
-        {% endfor %}
-    </div>
-</div>
-{% else %}
-<label class="visually-hidden">{% trans "Quick Start Timer" %}</label>
-<button class="btn m-0 p-0 text-success">
-    <i class="icon-2x icon-timer" aria-hidden="true"></i>
-</button>
-{% endif %}
+            <a class="m-0 p-0 text-success"
+               title="{% trans "Quick Start Timer" %}"
+               href="#"
+               role="button"
+               id="quick-timer-menu-toggle"
+               data-bs-toggle="dropdown"
+               aria-haspopup="true"
+               aria-expanded="false"><i class="icon-2x icon-timer" aria-hidden="true"></i>
+            </a>
+            <div class="dropdown-menu dropdown-menu-end"
+                 aria-labelledby="quick-timer-menu-toggle">
+                <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
+                {% for child in children %}
+                    <button class="dropdown-item d-flex align-items-center"
+                            type="submit"
+                            name="child"
+                            value="{{ child.pk }}">
+                        {% include "core/child_thumbnail.html" %}
+                        <span class="text-wrap ms-2">{{ child }}</span>
+                    </button>
+                {% endfor %}
+            </div>
+        </div>
+    {% else %}
+        <label class="visually-hidden">{% trans "Quick Start Timer" %}</label>
+        <button class="btn m-0 p-0 text-success">
+            <i class="icon-2x icon-timer" aria-hidden="true"></i>
+        </button>
+    {% endif %}
 </form>

--- a/core/templates/core/timer_detail.html
+++ b/core/templates/core/timer_detail.html
@@ -25,60 +25,60 @@
             </p>
             <div class="d-grid gap-4 mb-4">
                 {% if perms.core.add_feeding %}
-                <a class="btn btn-success btn-lg"
-                   href="{% instance_add_url 'core:feeding-add' %}"
-                   role="button"><i class="icon-feeding" aria-hidden="true"></i>
-                {% trans "Feeding" %}
-            </a>
-        {% endif %}
-        {% if perms.core.add_pumping %}
-        <a class="btn btn-success btn-lg"
-           href="{% instance_add_url 'core:pumping-add' %}"
-           role="button"><i class="icon-pumping" aria-hidden="true"></i>
-        {% trans "Pumping" %}
-    </a>
-{% endif %}
-{% if perms.core.add_sleep %}
-<a class="btn btn-success btn-lg"
-   href="{% instance_add_url 'core:sleep-add' %}"
-   role="button"><i class="icon-sleep" aria-hidden="true"></i>
-{% trans "Sleep" %}
-</a>
-{% endif %}
-{% if perms.core.add_tummytime %}
-<a class="btn btn-success btn-lg"
-   href="{% instance_add_url 'core:tummytime-add' %}"
-   role="button"><i class="icon-tummytime" aria-hidden="true"></i>
-{% trans "Tummy Time" %}
-</a>
-{% endif %}
-</div>
-<div class="center-block"
-     role="group"
-     aria-label="{% trans "Timer actions" %}">
-    {% if perms.core.delete_timer %}
-        <a class="btn btn-lg btn-danger"
-           href="{% url 'core:timer-delete' timer.id %}"
-           role="button"><i class="icon-delete" aria-hidden="true"></i></a>
-    {% endif %}
-    {% if perms.core.change_timer %}
-        <a class="btn btn-lg btn-primary"
-           href="{% url 'core:timer-update' timer.id %}"
-           role="button"><i class="icon-update" aria-hidden="true"></i></a>
-        <form action="{% url 'core:timer-restart' timer.id %}"
-              role="form"
-              method="post"
-              class="d-inline">
-            {% csrf_token %}
-            <label class="visually-hidden">{% trans "Restart timer" %}</label>
-            <button type="submit" class="btn btn-lg btn-secondary">
-                <i class="icon-refresh" aria-hidden="true"></i>
-            </button>
-        </form>
-    {% endif %}
-</div>
-</div>
-</div>
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:feeding-add' %}"
+                       role="button"><i class="icon-feeding" aria-hidden="true"></i>
+                        {% trans "Feeding" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_pumping %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:pumping-add' %}"
+                       role="button"><i class="icon-pumping" aria-hidden="true"></i>
+                        {% trans "Pumping" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_sleep %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:sleep-add' %}"
+                       role="button"><i class="icon-sleep" aria-hidden="true"></i>
+                        {% trans "Sleep" %}
+                    </a>
+                {% endif %}
+                {% if perms.core.add_tummytime %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% instance_add_url 'core:tummytime-add' %}"
+                       role="button"><i class="icon-tummytime" aria-hidden="true"></i>
+                        {% trans "Tummy Time" %}
+                    </a>
+                {% endif %}
+            </div>
+            <div class="center-block"
+                 role="group"
+                 aria-label="{% trans "Timer actions" %}">
+                {% if perms.core.delete_timer %}
+                    <a class="btn btn-lg btn-danger"
+                       href="{% url 'core:timer-delete' timer.id %}"
+                       role="button"><i class="icon-delete" aria-hidden="true"></i></a>
+                {% endif %}
+                {% if perms.core.change_timer %}
+                    <a class="btn btn-lg btn-primary"
+                       href="{% url 'core:timer-update' timer.id %}"
+                       role="button"><i class="icon-update" aria-hidden="true"></i></a>
+                    <form action="{% url 'core:timer-restart' timer.id %}"
+                          role="form"
+                          method="post"
+                          class="d-inline">
+                        {% csrf_token %}
+                        <label class="visually-hidden">{% trans "Restart timer" %}</label>
+                        <button type="submit" class="btn btn-lg btn-secondary">
+                            <i class="icon-refresh" aria-hidden="true"></i>
+                        </button>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
 {% endblock %}
 {% block javascript %}
     <script type="application/javascript">BabyBuddy.Timer.run({{ timer.id }}, 'timer-status');</script>

--- a/core/templates/core/timer_nav.html
+++ b/core/templates/core/timer_nav.html
@@ -1,57 +1,57 @@
 {% load i18n %}
 <li class="nav-item dropdown">
-<a id="nav-timer-menu-link"
-   class="nav-link dropdown-toggle"
-   href="#"
-   data-bs-toggle="dropdown"
-   aria-haspopup="true"
-   aria-expanded="false"><i class="icon-timer" aria-hidden="true"></i>
-{% trans "Timers" %}
-</a>
-<div class="dropdown-menu" aria-labelledby="nav-timer-menu-link">
-    {% if perms.core.add_timer %}
-        <a class="dropdown-item" href="{% url 'core:timer-add' %}">
-            <i class="icon-add" aria-hidden="true"></i> {% trans "Start Timer" %}
-        </a>
-    {% endif %}
-    {% if perms.core.view_timer %}
-        <a class="dropdown-item" href="{% url 'core:timer-list' %}">
-            <i class="icon-list" aria-hidden="true"></i> {% trans "View Timers" %}
-        </a>
-    {% endif %}
-    {% if perms.core.add_timer %}
-        <form action="{% url 'core:timer-add-quick' %}"
-              role="form"
-              method="post"
-              class="d-inline">
-            {% csrf_token %}
-            {% if children.count > 1 %}
-                <div class="dropdown-divider"></div>
-                <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
-                {% for child in children %}
-                    <button class="dropdown-item d-flex align-items-center"
-                            type="submit"
-                            name="child"
-                            value="{{ child.pk }}">
-                        {% include "core/child_thumbnail.html" %}
-                        <span class="text-wrap ms-2">{{ child }}</span>
+    <a id="nav-timer-menu-link"
+       class="nav-link dropdown-toggle"
+       href="#"
+       data-bs-toggle="dropdown"
+       aria-haspopup="true"
+       aria-expanded="false"><i class="icon-timer" aria-hidden="true"></i>
+        {% trans "Timers" %}
+    </a>
+    <div class="dropdown-menu" aria-labelledby="nav-timer-menu-link">
+        {% if perms.core.add_timer %}
+            <a class="dropdown-item" href="{% url 'core:timer-add' %}">
+                <i class="icon-add" aria-hidden="true"></i> {% trans "Start Timer" %}
+            </a>
+        {% endif %}
+        {% if perms.core.view_timer %}
+            <a class="dropdown-item" href="{% url 'core:timer-list' %}">
+                <i class="icon-list" aria-hidden="true"></i> {% trans "View Timers" %}
+            </a>
+        {% endif %}
+        {% if perms.core.add_timer %}
+            <form action="{% url 'core:timer-add-quick' %}"
+                  role="form"
+                  method="post"
+                  class="d-inline">
+                {% csrf_token %}
+                {% if children.count > 1 %}
+                    <div class="dropdown-divider"></div>
+                    <h6 class="dropdown-header">{% trans "Quick Start Timer For…" %}</h6>
+                    {% for child in children %}
+                        <button class="dropdown-item d-flex align-items-center"
+                                type="submit"
+                                name="child"
+                                value="{{ child.pk }}">
+                            {% include "core/child_thumbnail.html" %}
+                            <span class="text-wrap ms-2">{{ child }}</span>
+                        </button>
+                    {% endfor %}
+                {% else %}
+                    <button class="dropdown-item" type="submit">
+                        <i class="icon-timer" aria-hidden="true"></i> {% trans "Quick Start Timer" %}
                     </button>
-                {% endfor %}
-            {% else %}
-                <button class="dropdown-item" type="submit">
-                    <i class="icon-timer" aria-hidden="true"></i> {% trans "Quick Start Timer" %}
-                </button>
-            {% endif %}
-        </form>
-    {% endif %}
-    {% if timers %}
-        <div class="dropdown-divider"></div>
-        <h6 class="dropdown-header">{% trans "Timers" %}</h6>
-        {% for timer in timers %}
-            <a class="dropdown-item" href="{% url 'core:timer-detail' timer.id %}">{{ timer.title_with_child }}</a>
-        {% empty %}
-            <a class="dropdown-item disabled" href="#">{% trans "None" %}</a>
-        {% endfor %}
-    {% endif %}
-</div>
+                {% endif %}
+            </form>
+        {% endif %}
+        {% if timers %}
+            <div class="dropdown-divider"></div>
+            <h6 class="dropdown-header">{% trans "Timers" %}</h6>
+            {% for timer in timers %}
+                <a class="dropdown-item" href="{% url 'core:timer-detail' timer.id %}">{{ timer.title_with_child }}</a>
+            {% empty %}
+                <a class="dropdown-item disabled" href="#">{% trans "None" %}</a>
+            {% endfor %}
+        {% endif %}
+    </div>
 </li>

--- a/core/templates/core/widget_tag_editor.html
+++ b/core/templates/core/widget_tag_editor.html
@@ -47,9 +47,7 @@
             {% endfor %}
         {% endif %}
     </div>
-    <input type="hidden"
-           name="{{ widget.name }}"
-           value="{% for t in widget.value %}&quot;{{ t.name }}&quot;{% if not forloop.last %},{% endif %}{% endfor %}">
+    <input type="hidden" name="{{ widget.name }}" value="{% for t in widget.value %}&quot;{{ t.name }}&quot;{% if not forloop.last %},{% endif %}{% endfor %}">
     <div class="modal fade tag-editor-error-modal">
         <div class="modal-dialog modal-sm" role="document">
             <div class="modal-content">

--- a/core/tests/tests_templates.py
+++ b/core/tests/tests_templates.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from unittest import TestCase
+
+
+class NoteListTemplateTests(TestCase):
+    def test_empty_notes_row_accounts_for_optional_child_column(self):
+        template = (
+            Path(__file__).parents[1] / "templates" / "core" / "note_list.html"
+        ).read_text()
+
+        self.assertIn(
+            '<th colspan="{% if not unique_child %} 6 {% else %} 5 {% endif %}">',
+            template,
+        )

--- a/dashboard/templates/dashboard/dashboard.html
+++ b/dashboard/templates/dashboard/dashboard.html
@@ -22,7 +22,7 @@
                                         <img src="{% static 'babybuddy/img/core/child-placeholder.png' %}"
                                              class="child-photo img-fluid" />
                                     {% endif %}
-                                </a>
+                                    </a>
                                 <div class="card-body text-center">
                                     <h4 class="card-title">{{ object }}</h4>
                                     <div class="card-text">
@@ -33,11 +33,11 @@
                                         </p>
                                         {% include 'dashboard/child_button_group.html' %}
                                     </div>
-                                </div>
-                            </div>
+                                    </div>
+                                    </div>
+                                    </div>
+                            {% endfor %}
                         </div>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
-    {% endblock %}
+                    </div>
+                    </div>
+            {% endblock %}


### PR DESCRIPTION
Fixes #918

The empty-state table cell now spans all visible Notes columns: six when the Child column is shown and five otherwise.

Tests:
- `python3 -m unittest core.tests.tests_templates -v`
- `python3 -m py_compile core/tests/tests_templates.py`
- `git diff --check`