### PR TITLE
Set crossorigin to use-credentials for manifest file

### DIFF
--- a/babybuddy/templates/babybuddy/base.html
+++ b/babybuddy/templates/babybuddy/base.html
@@ -21,6 +21,7 @@
               type="image/svg+xml"
               href="{% static "babybuddy/root/favicon.svg" %}?v=20210925" />
         <link rel="manifest"
+              crossorigin="use-credentials"
               href="{% static "babybuddy/root/site.webmanifest" %}?v=20211225" />
         <link rel="mask-icon"
               href="{% static "babybuddy/root/safari-pinned-tab.svg" %}?v=20211218"


### PR DESCRIPTION
Addresses #1108 - sets `crossorigin` to `use-credentials`, which will instruct the browser to utilize the session cookies when fetching the manifest file, which will allow it to retrieve the file behind an authentication layer.