### PR TITLE
fix(core): omit child from timer update message when unset

### DIFF
--- a/core/tests/tests_forms.py
+++ b/core/tests/tests_forms.py
@@ -812,6 +812,18 @@ class TimerFormsTestCase(FormsTestCaseBase):
         self.timer.refresh_from_db()
         self.assertEqual(self.localtime_string(self.timer.start), params["start"])
 
+    def test_edit_without_child_message(self):
+        timer = models.Timer.objects.create(user=self.user)
+        params = {
+            "child": "",
+            "name": "Childless Timer",
+            "start": self.localtime_string(timer.start),
+        }
+        page = self.c.post("/timers/{}/edit/".format(timer.id), params, follow=True)
+        self.assertEqual(page.status_code, 200)
+        self.assertNotContains(page, "Timer entry for None updated.")
+        self.assertContains(page, "Timer entry updated.")
+
 
 class ValidationsTestCase(FormsTestCaseBase):
     def test_validate_date(self):

--- a/core/views.py
+++ b/core/views.py
@@ -59,7 +59,7 @@ class CoreAddView(PermissionRequiredMixin, SuccessMessageMixin, CreateView):
 class CoreUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView):
     def get_success_message(self, cleaned_data):
         cleaned_data["model"] = self.model._meta.verbose_name.title()
-        if "child" in cleaned_data:
+        if cleaned_data.get("child"):
             self.success_message = _("%(model)s entry for %(child)s updated.")
         else:
             self.success_message = _("%(model)s entry updated.")


### PR DESCRIPTION
Fixes #922

Editing a timer that has no child attached renders the success message with a literal `None`:

> Timer entry for None updated.

### Cause

`CoreUpdateView.get_success_message` tested `"child" in cleaned_data`, which checks that the key exists rather than that it holds a value:

```python
if "child" in cleaned_data:
    self.success_message = _("%(model)s entry for %(child)s updated.")
else:
    self.success_message = _("%(model)s entry updated.")
```

`Timer.child` is the only optional child foreign key in the project (`blank=True, null=True`) and `TimerForm` includes the field, so the key is always present holding `None`, and the first branch interpolates it.

Testing the value instead selects the existing fallback string, which is already translated in every locale, so no new translatable string is introduced.

This is the shape @cdubz agreed to on the issue — "This makes sense as a fix."

### Scope

`CoreAddView` carries the same pattern but is deliberately left alone. `TimerAdd` does not inherit from it, and no other model permits a null child, so it cannot be reached with one.

### Before / after

The same timer and form, on the same instance:

**Before**

<img width="1643" height="320" alt="Timer detail page showing the message: Timer entry for None updated." src="https://github.com/user-attachments/assets/718bc418-a20e-42e9-9956-00702fe74d77" />

**After**

<img width="1643" height="320" alt="The same page showing the message: Timer entry updated." src="https://github.com/user-attachments/assets/0151a256-7ed4-4310-9c66-843286f98f32" />

### Testing

Manually:

1. Create a timer with no child — the quick start timer control, or `Timer.objects.create(user=<user>)`
2. Edit it and save without changing anything
3. The message reads "Timer entry updated." A timer that does have a child still reads "Timer entry for &lt;name&gt; updated."

Automated: `TimerFormsTestCase.test_edit_without_child_message` is new. `test_edit` already edited a childless timer but asserted only on name and start time, so the message itself was uncovered. The new test fails against `master` and passes with the fix, and is committed ahead of it so the history shows the defect before the resolution.

`gulp test` reports 327 passing against 326 on `master` — the difference is exactly the new test.

### Note on the commits

Both were made with `--no-verify`, disclosed in the commit messages. The pre-commit hook runs `gulp lint`, which calls Node's `spawn("npx", ...)` without a shell; on Windows `npx` is `npx.cmd`, which `spawn` cannot execute, so the hook exits with `spawn npx ENOENT` before checking anything.

I ran the checks covering these changes by hand instead — `black --check` clean across all 192 files, `djlint --check` clean. Prettier does not process Python files. Happy to open a separate issue for the Windows `spawn` problem if that would be useful.
