### PR TITLE
Add Recent Notes dashboard card (#1038)

### DIFF
--- a/dashboard/templates/cards/notes_recent.html
+++ b/dashboard/templates/cards/notes_recent.html
@@ -1,0 +1,25 @@
+{% extends 'cards/base.html' %}
+{% load datetime i18n %}
+{% block header %}
+    <a href="{% url 'core:note-list' %}">{% trans "Recent Notes" %}</a>
+{% endblock %}
+{% block title %}
+    {% if notes %}
+        <div>{{ notes|length }} <small class="text-muted">{% trans "recent" %}</small></div>
+        <small class="text-muted">{{ notes.0.time|time }} — {{ notes.0.note|truncatechars:40 }}</small>
+    {% else %}
+        {% trans "None" %}
+    {% endif %}
+{% endblock %}
+{% block content %}
+    {% if notes %}
+        {% for note in notes %}
+            <div class="py-1 border-bottom">
+                <small class="text-muted">{{ note.time|datetime_short }}</small>
+                <div>{{ note.note|truncatechars:120 }}</div>
+            </div>
+        {% endfor %}
+    {% else %}
+        {% trans "No notes" %}
+    {% endif %}
+{% endblock %}

--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -16,6 +16,7 @@
          data-masonry='{"percentPosition": true }'>
         <div class="col-sm-6 col-lg-4">{% card_timer_list object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_feeding_last object %}</div>
+        <div class="col-sm-6 col-lg-4">{% card_notes_recent object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_diaperchange_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_pumping_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_pumping_recent object %}</div>

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -909,3 +909,24 @@ def card_medication_last(context, child):
         "empty": not instance,
         "hide_empty": _hide_empty(context),
     }
+
+@register.inclusion_tag("cards/notes_recent.html", takes_context=True)
+def card_notes_recent(context, child):
+    """
+    Recent notes for the child dashboard — shows last 4 notes with
+    time and text so caregivers can see what's been recorded without
+    navigating to the notes list.
+    """
+    recent = (
+        models.Note.objects.filter(child=child)
+        .order_by("-time")[:4]
+    )
+
+    empty = len(recent) == 0
+
+    return {
+        "type": "note",
+        "notes": list(recent),
+        "empty": empty,
+        "hide_empty": _hide_empty(context),
+    }

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -910,6 +910,7 @@ def card_medication_last(context, child):
         "hide_empty": _hide_empty(context),
     }
 
+
 @register.inclusion_tag("cards/notes_recent.html", takes_context=True)
 def card_notes_recent(context, child):
     """
@@ -917,10 +918,7 @@ def card_notes_recent(context, child):
     time and text so caregivers can see what's been recorded without
     navigating to the notes list.
     """
-    recent = (
-        models.Note.objects.filter(child=child)
-        .order_by("-time")[:4]
-    )
+    recent = models.Note.objects.filter(child=child).order_by("-time")[:4]
 
     empty = len(recent) == 0
 


### PR DESCRIPTION
## Description

Adds a "Recent Notes" dashboard card showing the 4 most recent notes for the selected child. Addresses #1038.

The card displays each note's time and a truncated preview of the text, with a count summary in the header. When no notes exist, it shows an empty state consistent with other cards.

## Changes

- **New template:** `dashboard/templates/cards/notes_recent.html` — card layout matching the existing card design pattern
- **Template tag:** `card_notes_recent` in `dashboard/templatetags/cards.py` — queries the 4 most recent notes for the child
- **Dashboard layout:** Adds the card to `child.html` after the feeding card

## Screenshots

<img width="1878" height="1194" alt="screenshot - baby buddy recent notes card and spit-up card" src="https://github.com/user-attachments/assets/ff6f0209-0b50-48f5-a8a2-1277eda2105e" />


Closes #1038
