### PR TITLE
Add spit-up tracking with amount levels and dashboard card (#1031)

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -331,3 +331,17 @@ class ProfileSerializer(serializers.ModelSerializer):
             "api_key",
         )
         extra_kwargs = {k: {"read_only": True} for k in fields}
+
+
+class SpitUpSerializer(CoreModelSerializer):
+    class Meta:
+        model = models.SpitUp
+        fields = (
+            "id",
+            "child",
+            "time",
+            "amount",
+            "appearance",
+            "related_feeding",
+            "notes",
+        )

--- a/api/urls.py
+++ b/api/urls.py
@@ -61,6 +61,7 @@ router.register(r"temperature", views.TemperatureViewSet)
 router.register(r"timers", views.TimerViewSet)
 router.register(r"tummy-times", views.TummyTimeViewSet)
 router.register(r"weight", views.WeightViewSet)
+router.register(r"spit-up", views.SpitUpViewSet, basename="spitup")
 
 router.add_detail_path("profile", "profile", views.ProfileView.as_view())
 router.add_detail_path(

--- a/api/views.py
+++ b/api/views.py
@@ -179,3 +179,11 @@ class ProfileView(views.APIView):
         )
         serializer = self.serializer_class(settings)
         return Response(serializer.data)
+
+
+class SpitUpViewSet(viewsets.ModelViewSet):
+    queryset = models.SpitUp.objects.all()
+    serializer_class = serializers.SpitUpSerializer
+    filterset_fields = ["child", "amount", "related_feeding"]
+    ordering_fields = ("time",)
+    ordering = "-time"

--- a/core/admin.py
+++ b/core/admin.py
@@ -299,6 +299,14 @@ class WeightAdmin(ImportExportMixin, ExportActionMixin, admin.ModelAdmin):
     resource_class = WeightImportExportResource
 
 
+@admin.register(models.SpitUp)
+class SpitUpAdmin(ImportExportMixin, ExportActionMixin, admin.ModelAdmin):
+    list_display = ("child", "time", "amount", "appearance", "related_feeding")
+    list_filter = ("amount", "appearance")
+    search_fields = ("appearance", "notes")
+    raw_id_fields = ("related_feeding",)
+
+
 class TaggedItemInline(admin.StackedInline):
     model = models.Tagged
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -509,3 +509,44 @@ class WeightForm(CoreModelForm, TaggableModelForm):
             "date": DateInput(),
             "notes": forms.Textarea(attrs={"rows": 5}),
         }
+
+
+class SpitUpForm(CoreModelForm):
+    fieldsets = [
+        {"fields": ["child", "time", "amount", "appearance"], "layout": "required"},
+        {
+            "fields": ["related_feeding"],
+            "layout": "advanced",
+            "layout_attrs": {"label": "Link to Feeding"},
+        },
+        {"fields": ["notes"], "layout": "advanced"},
+    ]
+
+    class Meta:
+        model = models.SpitUp
+        fields = ["child", "time", "amount", "appearance", "related_feeding", "notes"]
+        widgets = {
+            "child": ChildRadioSelect,
+            "time": DateTimeInput(),
+            "amount": PillRadioSelect(),
+            "related_feeding": forms.Select(),
+            "notes": forms.Textarea(attrs={"rows": 3}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Populate related_feeding dropdown with recent feedings
+        recent_feedings = models.Feeding.objects.order_by("-end")[:20]
+        choices = [("", _("---------"))]
+        for f in recent_feedings:
+            label = f"{f.end.strftime('%m/%d %I:%M %p')} — {f.get_method_display()}"
+            if f.amount:
+                label += f" ({f.amount}ml)"
+            choices.append((f.id, label))
+        self.fields["related_feeding"].choices = choices
+
+        # Auto-select most recent feeding as default
+        if not (self.instance and self.instance.pk):
+            latest = models.Feeding.objects.order_by("-end").first()
+            if latest:
+                self.fields["related_feeding"].initial = latest.id

--- a/core/forms.py
+++ b/core/forms.py
@@ -535,18 +535,40 @@ class SpitUpForm(CoreModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Populate related_feeding dropdown with recent feedings
-        recent_feedings = models.Feeding.objects.order_by("-end")[:20]
-        choices = [("", _("---------"))]
-        for f in recent_feedings:
-            label = f"{f.end.strftime('%m/%d %I:%M %p')} — {f.get_method_display()}"
+
+        def _feeding_label(f):
+            local_end = timezone.localtime(f.end)
+            label = f"{local_end.strftime('%m/%d %I:%M %p')} — {f.get_method_display()}"
             if f.amount:
                 label += f" ({f.amount}ml)"
-            choices.append((f.id, label))
-        self.fields["related_feeding"].choices = choices
+            return label
 
-        # Auto-select most recent feeding as default
-        if not (self.instance and self.instance.pk):
+        # Build related_feeding choices:
+        # - New record: show 20 most recent feedings
+        # - Existing record: show feedings within +/-6h of this spit-up's time,
+        #   so the relevant feeding stays selectable when editing old entries
+        choices = [("", _("---------"))]
+        if self.instance and self.instance.pk and self.instance.time:
+            ref_time = self.instance.time
+            window = timezone.timedelta(hours=6)
+            feedings = list(
+                models.Feeding.objects.filter(
+                    end__range=(ref_time - window, ref_time + window)
+                ).order_by("-end")
+            )
+            # Always include the currently-selected feeding even if outside window
+            if self.instance.related_feeding_id:
+                selected_id = self.instance.related_feeding_id
+                if not any(f.id == selected_id for f in feedings):
+                    feedings.insert(0, self.instance.related_feeding)
+            for f in feedings:
+                choices.append((f.id, _feeding_label(f)))
+        else:
+            for f in models.Feeding.objects.order_by("-end")[:20]:
+                choices.append((f.id, _feeding_label(f)))
+            # Auto-select most recent feeding as default
             latest = models.Feeding.objects.order_by("-end").first()
             if latest:
                 self.fields["related_feeding"].initial = latest.id
+
+        self.fields["related_feeding"].choices = choices

--- a/core/migrations/0037_spit_up.py
+++ b/core/migrations/0037_spit_up.py
@@ -35,9 +35,11 @@ class Migration(migrations.Migration):
                     "amount",
                     models.CharField(
                         choices=[
-                            ("small", "Small"),
-                            ("medium", "Medium"),
-                            ("large", "Large"),
+                            ("trace", "Trace (just a spot)"),
+                            ("dribble", "Dribble (a little)"),
+                            ("moderate", "Moderate (noticeable)"),
+                            ("large", "Large (soaks clothes)"),
+                            ("projectile", "Projectile / lots"),
                         ],
                         blank=True,
                         default="",

--- a/core/migrations/0037_spit_up.py
+++ b/core/migrations/0037_spit_up.py
@@ -1,0 +1,90 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0036_medication"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SpitUp",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "time",
+                    models.DateTimeField(
+                        blank=False,
+                        default=django.utils.timezone.localtime,
+                        null=False,
+                        verbose_name="Time",
+                    ),
+                ),
+                (
+                    "amount",
+                    models.CharField(
+                        choices=[
+                            ("small", "Small"),
+                            ("medium", "Medium"),
+                            ("large", "Large"),
+                        ],
+                        blank=True,
+                        default="",
+                        max_length=50,
+                        verbose_name="Amount",
+                    ),
+                ),
+                (
+                    "appearance",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        max_length=255,
+                        verbose_name="Appearance",
+                        help_text="e.g., curdled, watery, clear, milky",
+                    ),
+                ),
+                (
+                    "notes",
+                    models.TextField(blank=True, null=True, verbose_name="Notes"),
+                ),
+                (
+                    "child",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="spit_ups",
+                        to="core.child",
+                        verbose_name="Child",
+                    ),
+                ),
+                (
+                    "related_feeding",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        null=True,
+                        blank=True,
+                        related_name="spit_ups",
+                        to="core.feeding",
+                        verbose_name="Related feeding",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Spit-Up",
+                "verbose_name_plural": "Spit-Up",
+                "ordering": ["-time"],
+                "default_permissions": ("view", "add", "change", "delete"),
+            },
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -881,3 +881,66 @@ class WeightPercentile(models.Model):
 
     def __str__(self):
         return f"Sex: {self.sex}, Age: {self.age_in_days} days, p3: {self.p3_weight} kg, p15: {self.p15_weight} kg, p50: {self.p50_weight} kg, p85: {self.p85_weight} kg, p97: {self.p97_weight} kg"
+
+
+class SpitUp(models.Model):
+    """
+    Spit-up tracking — time, relative amount, appearance, optional link
+    to preceding feeding. Enables correlation analysis (e.g., "does he
+    spit up more after bottle feedings than breast?").
+    """
+
+    model_name = "spit_up"
+
+    AMOUNT_CHOICES = [
+        ("small", _("Small")),
+        ("medium", _("Medium")),
+        ("large", _("Large")),
+    ]
+
+    child = models.ForeignKey(
+        "Child",
+        on_delete=models.CASCADE,
+        related_name="spit_ups",
+        verbose_name=_("Child"),
+    )
+    time = models.DateTimeField(
+        blank=False,
+        default=timezone.localtime,
+        null=False,
+        verbose_name=_("Time"),
+    )
+    amount = models.CharField(
+        max_length=50,
+        choices=AMOUNT_CHOICES,
+        blank=True,
+        default="",
+        verbose_name=_("Amount"),
+    )
+    appearance = models.CharField(
+        blank=True,
+        default="",
+        max_length=255,
+        verbose_name=_("Appearance"),
+        help_text=_("e.g., curdled, watery, clear, milky"),
+    )
+    related_feeding = models.ForeignKey(
+        "Feeding",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="spit_ups",
+        verbose_name=_("Related feeding"),
+    )
+    notes = models.TextField(blank=True, null=True, verbose_name=_("Notes"))
+
+    objects = models.Manager()
+
+    class Meta:
+        default_permissions = ("view", "add", "change", "delete")
+        ordering = ["-time"]
+        verbose_name = _("Spit-Up")
+        verbose_name_plural = _("Spit-Up")
+
+    def __str__(self):
+        return str(_("Spit-Up"))

--- a/core/models.py
+++ b/core/models.py
@@ -893,9 +893,11 @@ class SpitUp(models.Model):
     model_name = "spit_up"
 
     AMOUNT_CHOICES = [
-        ("small", _("Small")),
-        ("medium", _("Medium")),
-        ("large", _("Large")),
+        ("trace", _("Trace (just a spot)")),
+        ("dribble", _("Dribble (a little)")),
+        ("moderate", _("Moderate (noticeable)")),
+        ("large", _("Large (soaks clothes)")),
+        ("projectile", _("Projectile / lots")),
     ]
 
     child = models.ForeignKey(

--- a/core/templates/core/spitup_confirm_delete.html
+++ b/core/templates/core/spitup_confirm_delete.html
@@ -1,0 +1,17 @@
+{% extends 'babybuddy/page.html' %}
+{% load babybuddy i18n widget_tweaks %}
+{% block title %}
+    {% trans "Delete Spit-Up Entry" %}
+{% endblock %}
+{% block breadcrumbs %}
+    <li class="breadcrumb-item"><a href="{% url 'core:spitup-list' %}">{% trans "Spit-Up" %}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{% trans "Delete" %}</li>
+{% endblock %}
+{% block content %}
+    <form role="form" method="post">
+        {% csrf_token %}
+        <h1>{% confirm_delete_text object %}</h1>
+        <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
+        <a href="{% url 'core:spitup-list' %}" class="btn btn-default">{% trans "Cancel" %}</a>
+    </form>
+{% endblock %}

--- a/core/templates/core/spitup_form.html
+++ b/core/templates/core/spitup_form.html
@@ -1,0 +1,21 @@
+{% extends 'babybuddy/page.html' %}
+{% load datetime i18n %}
+{% block title %}
+    {% if object %}{{ object }}{% else %}{% trans "Add Spit-Up Entry" %}{% endif %}
+{% endblock %}
+{% block breadcrumbs %}
+    <li class="breadcrumb-item"><a href="{% url 'core:spitup-list' %}">{% trans "Spit-Up" %}</a></li>
+    {% if object %}
+        <li class="breadcrumb-item active" aria-current="page">{% trans "Update" %}</li>
+    {% else %}
+        <li class="breadcrumb-item active" aria-current="page">{% trans "Add Spit-Up Entry" %}</li>
+    {% endif %}
+{% endblock %}
+{% block content %}
+    {% if object %}
+        <h1>{% trans "Update" %} <span class="text-info">{{ object }}</span></h1>
+    {% else %}
+        <h1>{% trans "Add Spit-Up Entry" %}</h1>
+    {% endif %}
+    {% include 'babybuddy/form.html' %}
+{% endblock %}

--- a/core/templates/core/spitup_list.html
+++ b/core/templates/core/spitup_list.html
@@ -1,0 +1,58 @@
+{% extends 'babybuddy/page.html' %}
+{% load datetime duration misc i18n widget_tweaks %}
+{% block title %}
+    {% trans "Spit-Up" %}
+{% endblock %}
+{% block breadcrumbs %}
+    <li class="breadcrumb-item active" aria-current="page">{% trans "Spit-Up" %}</li>
+{% endblock %}
+{% block content %}
+    <h1>
+        {% trans "Spit-Up" %}
+        {% if perms.core.add_spitup %}
+            <a href="{% url 'core:spitup-add' %}" class="btn btn-sm btn-success">
+                <i class="icon-add" aria-hidden="true"></i> {% trans "Add Entry" %}
+            </a>
+        {% endif %}
+    </h1>
+    {% if object_list %}
+        <div class="table-responsive">
+            <table class="table table-instances table-borderless table-striped table-hover align-middle">
+                <thead>
+                    <tr>
+                        <th>{% trans "Actions" %}</th>
+                        <th>{% trans "Time" %}</th>
+                        <th>{% trans "Amount" %}</th>
+                        <th>{% trans "Appearance" %}</th>
+                        <th>{% trans "After Feeding" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for entry in object_list %}
+                        <tr>
+                            <td>
+                                <a href="{% url 'core:spitup-update' entry.id %}"
+                                   class="btn btn-sm btn-primary"><i class="icon-update"></i></a>
+                                <a href="{% url 'core:spitup-delete' entry.id %}"
+                                   class="btn btn-sm btn-danger"><i class="icon-trash"></i></a>
+                            </td>
+                            <td>{{ entry.time|datetime_short }}</td>
+                            <td>{{ entry.get_amount_display|default:"—" }}</td>
+                            <td>{{ entry.appearance|default:"—" }}</td>
+                            <td>
+                                {% if entry.related_feeding %}
+                                    {{ entry.related_feeding.end|time }} · {{ entry.related_feeding.get_method_display }}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% include 'babybuddy/paginator.html' %}
+    {% else %}
+        <p class="text-muted my-5">{% trans "No spit-up entries yet." %}</p>
+    {% endif %}
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -139,4 +139,10 @@ urlpatterns = [
     path("bmi/add/", views.BMIAdd.as_view(), name="bmi-add"),
     path("bmi/<int:pk>/", views.BMIUpdate.as_view(), name="bmi-update"),
     path("bmi/<int:pk>/delete/", views.BMIDelete.as_view(), name="bmi-delete"),
+    path("spit-up/", views.SpitUpList.as_view(), name="spitup-list"),
+    path("spit-up/add/", views.SpitUpAdd.as_view(), name="spitup-add"),
+    path("spit-up/<int:pk>/", views.SpitUpUpdate.as_view(), name="spitup-update"),
+    path(
+        "spit-up/<int:pk>/delete/", views.SpitUpDelete.as_view(), name="spitup-delete"
+    ),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext as _
 from django.views.generic.base import RedirectView, TemplateView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView, FormView
+from django.views.generic.list import ListView
 
 from babybuddy.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from babybuddy.views import BabyBuddyFilterView, BabyBuddyPaginatedView
@@ -632,3 +633,32 @@ class WeightDelete(CoreDeleteView):
     model = models.Weight
     permission_required = ("core.delete_weight",)
     success_url = reverse_lazy("core:weight-list")
+
+
+class SpitUpList(PermissionRequiredMixin, ListView):
+    model = models.SpitUp
+    template_name = "core/spitup_list.html"
+    permission_required = ("core.view_spitup",)
+    paginate_by = 30
+
+
+class SpitUpAdd(CoreAddView):
+    model = models.SpitUp
+    permission_required = ("core.add_spitup",)
+    form_class = forms.SpitUpForm
+    success_url = reverse_lazy("core:spitup-list")
+    success_message = _("Spit-up entry added!")
+
+
+class SpitUpUpdate(CoreUpdateView):
+    model = models.SpitUp
+    permission_required = ("core.change_spitup",)
+    form_class = forms.SpitUpForm
+    success_url = reverse_lazy("core:spitup-list")
+    success_message = _("Spit-up entry updated.")
+
+
+class SpitUpDelete(CoreDeleteView):
+    model = models.SpitUp
+    permission_required = ("core.delete_spitup",)
+    success_url = reverse_lazy("core:spitup-list")

--- a/dashboard/templates/cards/spitup.html
+++ b/dashboard/templates/cards/spitup.html
@@ -1,0 +1,34 @@
+{% extends 'cards/base.html' %}
+{% load datetime duration i18n %}
+{% block header %}
+    <a href="{% url 'core:spitup-list' %}">{% trans "Spit-Up" %}</a>
+{% endblock %}
+{% block title %}
+    {% if latest %}
+        <div>{{ count_24h }} <small class="text-muted">{% trans "episodes / 24h" %}</small></div>
+        {% if by_amount %}
+        <small class="text-muted">
+            {% for amount, count in by_amount.items %}
+                {{ count }}× {{ amount }}{% if not forloop.last %} · {% endif %}
+            {% endfor %}
+        </small>
+        {% endif %}
+    {% else %}
+        {% trans "None" %}
+    {% endif %}
+{% endblock %}
+{% block content %}
+    {% if recent %}
+        {% for s in recent %}
+            <div class="d-flex justify-content-between align-items-center py-1">
+                <div>
+                    <small class="text-muted">{{ s.time|time }}</small>
+                    {{ s.get_amount_display|default:"—" }}
+                    {% if s.appearance %}<small class="text-muted">· {{ s.appearance }}</small>{% endif %}
+                </div>
+            </div>
+        {% endfor %}
+    {% else %}
+        {% trans "No spit-up logged" %}
+    {% endif %}
+{% endblock %}

--- a/dashboard/templates/cards/spitup.html
+++ b/dashboard/templates/cards/spitup.html
@@ -7,11 +7,11 @@
     {% if latest %}
         <div>{{ count_24h }} <small class="text-muted">{% trans "episodes / 24h" %}</small></div>
         {% if by_amount %}
-        <small class="text-muted">
-            {% for amount, count in by_amount.items %}
-                {{ count }}× {{ amount }}{% if not forloop.last %} · {% endif %}
-            {% endfor %}
-        </small>
+            <small class="text-muted">
+                {% for amount, count in by_amount.items %}
+                    {{ count }}× {{ amount }}{% if not forloop.last %} · {% endif %}
+                {% endfor %}
+            </small>
         {% endif %}
     {% else %}
         {% trans "None" %}

--- a/dashboard/templates/dashboard/child.html
+++ b/dashboard/templates/dashboard/child.html
@@ -16,6 +16,7 @@
          data-masonry='{"percentPosition": true }'>
         <div class="col-sm-6 col-lg-4">{% card_timer_list object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_feeding_last object %}</div>
+        <div class="col-sm-6 col-lg-4">{% card_spitup object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_diaperchange_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_pumping_last object %}</div>
         <div class="col-sm-6 col-lg-4">{% card_pumping_recent object %}</div>

--- a/dashboard/templatetags/cards.py
+++ b/dashboard/templatetags/cards.py
@@ -909,3 +909,39 @@ def card_medication_last(context, child):
         "empty": not instance,
         "hide_empty": _hide_empty(context),
     }
+
+
+@register.inclusion_tag("cards/spitup.html", takes_context=True)
+def card_spitup(context, child):
+    """
+    Recent spit-up summary: count in last 24h, last episode, and
+    frequency by amount severity.
+    """
+    from datetime import timedelta
+    from collections import Counter
+
+    now = timezone.now()
+    cutoff_24h = now - timedelta(hours=24)
+
+    recent = models.SpitUp.objects.filter(child=child).order_by("-time")[:10]
+
+    last_24h = [s for s in recent if s.time >= cutoff_24h]
+    count_24h = len(last_24h)
+
+    # Count by severity in last 24h
+    by_amount = Counter(s.get_amount_display() for s in last_24h if s.amount)
+
+    # Most recent episode
+    latest = recent[0] if recent else None
+
+    empty = len(recent) == 0
+
+    return {
+        "type": "note",
+        "recent": list(reversed(recent))[:5],  # newest first for display
+        "count_24h": count_24h,
+        "by_amount": dict(by_amount),
+        "latest": latest,
+        "empty": empty,
+        "hide_empty": _hide_empty(context),
+    }


### PR DESCRIPTION
## Description

Adds spit-up (reflux) tracking with amount levels and a dashboard card. Addresses #1031.

## Changes

**SpitUp model** with full CRUD:
- `time`, `amount` (small/medium/large), `appearance` (free text), `related_feeding` (optional FK to Feeding), `notes`
- Full admin registration, API serializer, URLs, views

**5-level amounts** with dashboard card:
- Amount choices: small, medium, large (extendable)
- Dashboard card shows: latest episode, 24h count, breakdown by amount level
- `related_feeding` dropdown is context-aware: when editing old entries, shows feedings within +/-6h of the spit-up time
- when adding a new spit-up record, the most recent feeding log is auto-selected / pre-filled in "recent feedings" (can be changed, of course).

## Files Changed

- `core/models.py`, `core/forms.py`, `core/views.py`, `core/admin.py`, `core/urls.py`
- `core/migrations/0037_spit_up.py`
- `api/serializers.py`, `api/urls.py`, `api/views.py`
- `dashboard/templatetags/cards.py`, `dashboard/templates/cards/spitup.html`, `dashboard/templates/dashboard/child.html`
- `core/templates/core/spitup_form.html`
- Tests

Closes #1031

## Screenshots
<img width="2403" height="1426" alt="screenshot - baby buddy spit-up logging form" src="https://github.com/user-attachments/assets/2bbe2365-549b-4899-801a-8de663f9fa52" />
<img width="1878" height="1194" alt="screenshot - baby buddy recent notes card and spit-up card" src="https://github.com/user-attachments/assets/95b04925-76a7-4771-b1bd-fd8b07f04e91" />
<img width="2812" height="1480" alt="screenshot - baby buddy spit-up add form" src="https://github.com/user-attachments/assets/4f20c845-e463-42ac-9956-9c7b20ffe397" />

