### PR TITLE
docs(api): document /api/medication/ and /api/profile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -36,5 +36,6 @@ mkdocs = "~=1.0"
 mkdocs-material = "~=9.0"
 tblib = "~=3.0"
 black = "~=26.0"
-djlint = "~=1.0"
+djlint = "==1.44.2"
 pysnooper = "~=1.0"
+

--- a/Pipfile
+++ b/Pipfile
@@ -36,6 +36,5 @@ mkdocs = "~=1.0"
 mkdocs-material = "~=9.0"
 tblib = "~=3.0"
 black = "~=26.0"
-djlint = "==1.44.2"
+djlint = "~=1.0"
 pysnooper = "~=1.0"
-

--- a/docs/api.md
+++ b/docs/api.md
@@ -78,7 +78,7 @@ curl -X GET https://[...]/api/profile -H 'Authorization: Token [...]'
     "email": "admin@example.com",
     "is_staff": true
   },
-  "language": "en",
+  "language": "en-US",
   "timezone": "UTC",
   "api_key": "2h23807gd72h7hop382p98hd823dw3g665g56"
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,7 @@ Currently, the following endpoints are available for `GET`, `OPTIONS`, and
 - `/api/feedings/`
 - `/api/head-circumference/`
 - `/api/height/`
+- `/api/medication/`
 - `/api/notes/`
 - `/api/pumping/`
 - `/api/sleep/`
@@ -25,6 +26,10 @@ Currently, the following endpoints are available for `GET`, `OPTIONS`, and
 - `/api/timers/`
 - `/api/tummy-times/`
 - `/api/weight/`
+
+In addition, the following read-only endpoint is available for `GET` requests:
+
+- `/api/profile`
 
 ## Authentication
 
@@ -52,6 +57,35 @@ The API schema in [OpenAPI format](https://swagger.io/specification/) can be
 found in the [`openapi-schema.yml`](https://github.com/babybuddy/babybuddy/tree/master/openapi-schema.yml)
 file in the project root. A live version is also available at the `/api/schema` path of
 a running instance.
+
+## Profile
+
+The `/api/profile` endpoint returns settings for the currently authenticated
+user. Unlike the model endpoints above, it only supports `GET` (no create,
+update, or delete).
+
+```shell
+curl -X GET https://[...]/api/profile -H 'Authorization: Token [...]'
+```
+
+```json
+{
+  "user": {
+    "id": 1,
+    "username": "admin",
+    "first_name": "",
+    "last_name": "",
+    "email": "admin@example.com",
+    "is_staff": true
+  },
+  "language": "en",
+  "timezone": "UTC",
+  "api_key": "2h23807gd72h7hop382p98hd823dw3g665g56"
+}
+```
+
+All fields are read-only. The `api_key` value is the same token shown on the
+User Settings page and used for [Authentication](#authentication).
 
 ## `GET` Method
 
@@ -109,6 +143,29 @@ curl -X GET https://[...]/api/sleep/1/ -H 'Authorization: Token [...]'
   "nap": false
 }
 ```
+
+```shell
+curl -X GET https://[...]/api/medication/1/ -H 'Authorization: Token [...]'
+```
+
+```json
+{
+  "id": 1,
+  "child": 3,
+  "name": "Acetaminophen",
+  "dosage": 2.5,
+  "dosage_unit": "ml",
+  "time": "2020-03-12T14:30:00.000000-07:00",
+  "next_dose_interval": "04:00:00",
+  "notes": "",
+  "tags": []
+}
+```
+
+Medication entries support filters including `child`, `name`, `dosage_unit`
+(`mg`, `ml`, `tablets`, `drops`), `date` / `date_min` / `date_max`, and `tags`.
+The optional `next_dose_interval` is a duration (e.g. `04:00:00`) until the next
+dose may be given.
 
 ### Response
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,6 +87,41 @@ curl -X GET https://[...]/api/profile -H 'Authorization: Token [...]'
 All fields are read-only. The `api_key` value is the same token shown on the
 User Settings page and used for [Authentication](#authentication).
 
+## Medication
+
+The `/api/medication/` endpoint records medication doses for a child. It supports
+the same `GET`, `OPTIONS`, `POST`, `PATCH`, and `DELETE` methods as the other
+model endpoints.
+
+```shell
+curl -X GET https://[...]/api/medication/1/ -H 'Authorization: Token [...]'
+```
+
+```json
+{
+  "id": 1,
+  "child": 3,
+  "name": "Acetaminophen",
+  "dosage": 2.5,
+  "dosage_unit": "ml",
+  "time": "2020-03-12T14:30:00.000000-07:00",
+  "next_dose_interval": "04:00:00",
+  "notes": "",
+  "tags": []
+}
+```
+
+`dosage` and `next_dose_interval` may be `null` when unset. When set,
+`next_dose_interval` is a duration (e.g. `04:00:00`) until the next dose may be
+given. `dosage_unit` is one of `mg`, `ml`, `tablets`, or `drops` (may be an
+empty string when unset).
+
+List filters include `child`, `name`, `dosage_unit`, `tags`, and
+`date` / `date_min` / `date_max`. Despite the `date*` names, those filters are
+ISO 8601 **datetime** filters on the `time` field (same pattern as other timed
+endpoints), for example `2020-03-12T14:30:00-07:00` — not bare `YYYY-MM-DD`
+dates.
+
 ## `GET` Method
 
 ### Request
@@ -143,29 +178,6 @@ curl -X GET https://[...]/api/sleep/1/ -H 'Authorization: Token [...]'
   "nap": false
 }
 ```
-
-```shell
-curl -X GET https://[...]/api/medication/1/ -H 'Authorization: Token [...]'
-```
-
-```json
-{
-  "id": 1,
-  "child": 3,
-  "name": "Acetaminophen",
-  "dosage": 2.5,
-  "dosage_unit": "ml",
-  "time": "2020-03-12T14:30:00.000000-07:00",
-  "next_dose_interval": "04:00:00",
-  "notes": "",
-  "tags": []
-}
-```
-
-Medication entries support filters including `child`, `name`, `dosage_unit`
-(`mg`, `ml`, `tablets`, `drops`), `date` / `date_min` / `date_max`, and `tags`.
-The optional `next_dose_interval` is a duration (e.g. `04:00:00`) until the next
-dose may be given.
 
 ### Response
 


### PR DESCRIPTION
## Summary
- Document `/api/medication/` in the endpoint list and add a GET example (fields, filters, `next_dose_interval`).
- Document read-only `/api/profile` (`GET` only) with an example response including `user`, `language`, `timezone`, and `api_key`.

These endpoints already exist in the API and OpenAPI schema (`openapi-schema.yml`); `docs/api.md` was simply out of date.

## Test plan
- [ ] Render `docs/api.md` in MkDocs / docs site preview
- [ ] Spot-check against `/api/schema` (or `openapi-schema.yml`) for medication + profile
- [ ] Confirm curl examples match live behavior on a demo instance